### PR TITLE
feat: add HTTP Basic Auth for web interface security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Claudeman Environment Configuration
+# Copy this file to .env and set your values
+
+# HTTP Basic Auth password (required to enable authentication)
+# If not set, the web interface is accessible without authentication
+CLAUDEMAN_PASSWORD=your_secure_password_here
+
+# HTTP Basic Auth username (optional, defaults to "admin")
+# CLAUDEMAN_USERNAME=admin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,22 @@ Claudeman is a Claude Code session manager with a web interface and autonomous R
 npm install
 ```
 
+## Authentication
+
+The web interface supports optional HTTP Basic Auth. To enable it:
+
+1. Copy `.env.example` to `.env`
+2. Set `CLAUDEMAN_PASSWORD` to your desired password
+3. Optionally set `CLAUDEMAN_USERNAME` (defaults to "admin")
+4. Restart the web server
+
+```bash
+cp .env.example .env
+# Edit .env and set CLAUDEMAN_PASSWORD=your_secure_password
+```
+
+When enabled, browsers will prompt for credentials before accessing the web interface.
+
 ## Commands
 
 **CRITICAL**: `npm run dev` runs CLI help, NOT the web server. Use `npx tsx src/index.ts web` for development.
@@ -470,6 +486,7 @@ All routes defined in `server.ts:buildServer()`. Key endpoint groups:
 
 | File | Purpose |
 |------|---------|
+| `.env` | Environment config (CLAUDEMAN_PASSWORD, CLAUDEMAN_USERNAME for HTTP Basic Auth) |
 | `~/.claudeman/state.json` | Full session state (all settings, tokens, respawn config, Ralph state), tasks, app config |
 | `~/.claudeman/state-inner.json` | Ralph loop/todo state per session (separate to reduce writes) |
 | `~/.claudeman/screens.json` | Screen session metadata (for recovery after restart) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/sdk": "^1.25.3",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
+        "dotenv": "^17.2.3",
         "fastify": "^5.1.0",
         "ink": "^6.6.0",
         "ink-spinner": "^5.0.0",
@@ -23,7 +24,8 @@
         "zod": "^4.3.6"
       },
       "bin": {
-        "claudeman": "dist/index.js"
+        "claudeman": "dist/index.js",
+        "claudeman-mcp": "dist/mcp-server.js"
       },
       "devDependencies": {
         "@types/node": "^20.14.0",
@@ -1913,6 +1915,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@modelcontextprotocol/sdk": "^1.25.3",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
+    "dotenv": "^17.2.3",
     "fastify": "^5.1.0",
     "ink": "^6.6.0",
     "ink-spinner": "^5.0.0",


### PR DESCRIPTION
Add optional password protection via environment variables:
- CLAUDEMAN_PASSWORD: enables auth when set
- CLAUDEMAN_USERNAME: optional, defaults to "admin"

Uses dotenv to load .env file. When enabled, browsers automatically prompt for credentials. Backward compatible - no auth if password unset.