### PR TITLE
fix: rebuild node-pty from source for Node.js 22+ compatibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -813,6 +813,11 @@ main() {
     info "Installing dependencies..."
     npm install --quiet --no-fund --no-audit 2>/dev/null || npm install --no-fund --no-audit
 
+    # Rebuild node-pty from source for Node.js 22+ compatibility
+    # The prebuilt binaries may not support newer Node.js ABI versions
+    info "Rebuilding node-pty for current Node.js version..."
+    npm rebuild node-pty --build-from-source --quiet 2>/dev/null || npm rebuild node-pty --build-from-source
+
     info "Building..."
     npm run build --quiet 2>/dev/null || npm run build
 


### PR DESCRIPTION
## Summary
- Adds `npm rebuild node-pty --build-from-source` step after `npm install` in the installer
- Fixes `posix_spawnp failed` errors when using Node.js 22+

## Problem
The prebuilt `node-pty` binaries (v1.1.0) don't support Node.js 22's ABI version (127). This causes the following error when starting Claudeman:

```
Error: posix_spawnp failed.
    at new UnixTerminal (node_modules/node-pty/lib/unixTerminal.js:92:24)
```

## Solution
Rebuild `node-pty` from source during installation to ensure it's compiled for the user's specific Node.js version and architecture.

## Testing
Verified on macOS (Apple Silicon, arm64) with Node.js v22.19.0:
- Before fix: PTY spawn fails with `posix_spawnp failed`
- After fix: PTY spawns successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)