### PR TITLE
fix: unset COLORTERM to fix xterm.js rendering issues

### DIFF
--- a/src/screen-manager.ts
+++ b/src/screen-manager.ts
@@ -258,7 +258,9 @@ export class ScreenManager extends EventEmitter {
 
     // Environment variables must be exported, not passed inline to nice
     // Using inline VAR=value before nice doesn't work correctly
+    // Unset COLORTERM to prevent truecolor issues - xterm.js doesn't handle inherited COLORTERM=truecolor well
     const envExports = [
+      'unset COLORTERM',
       'export CLAUDEMAN_SCREEN=1',
       `export CLAUDEMAN_SESSION_ID=${sessionId}`,
       `export CLAUDEMAN_SCREEN_NAME=${screenName}`,

--- a/src/session.ts
+++ b/src/session.ts
@@ -825,7 +825,7 @@ export class Session extends EventEmitter {
             cols: 120,
             rows: 40,
             cwd: this.workingDir,
-            env: { ...process.env, TERM: 'xterm-256color' },
+            env: { ...process.env, TERM: 'xterm-256color', COLORTERM: undefined },
           });
         } catch (spawnErr) {
           console.error('[Session] Failed to spawn PTY for screen attachment:', spawnErr);
@@ -888,6 +888,7 @@ export class Session extends EventEmitter {
             ...process.env,
             PATH: getAugmentedPath(),
             TERM: 'xterm-256color',
+            COLORTERM: undefined,
             // Inform Claude it's running within Claudeman (helps prevent self-termination)
             CLAUDEMAN_SCREEN: '1',
             CLAUDEMAN_SESSION_ID: this.id,
@@ -1062,7 +1063,7 @@ export class Session extends EventEmitter {
             cols: 120,
             rows: 40,
             cwd: this.workingDir,
-            env: { ...process.env, TERM: 'xterm-256color' },
+            env: { ...process.env, TERM: 'xterm-256color', COLORTERM: undefined },
           });
         } catch (spawnErr) {
           console.error('[Session] Failed to spawn PTY for shell screen attachment:', spawnErr);
@@ -1098,6 +1099,7 @@ export class Session extends EventEmitter {
           env: {
             ...process.env,
             TERM: 'xterm-256color',
+            COLORTERM: undefined,
             CLAUDEMAN_SCREEN: '1',
             CLAUDEMAN_SESSION_ID: this.id,
             CLAUDEMAN_API_URL: process.env.CLAUDEMAN_API_URL || 'http://localhost:3000',
@@ -1227,6 +1229,7 @@ export class Session extends EventEmitter {
               ...process.env,
               PATH: getAugmentedPath(),
               TERM: 'xterm-256color',
+              COLORTERM: undefined,
               // Inform Claude it's running within Claudeman
               CLAUDEMAN_SCREEN: '1',
               CLAUDEMAN_SESSION_ID: this.id,


### PR DESCRIPTION
## Summary
- Unsets `COLORTERM` in all PTY spawns to fix rendering issues in xterm.js

## Problem
When `COLORTERM=truecolor` is inherited from the outer terminal (e.g., Ghostty, iTerm2), Claude Code's Ink UI tries to use truecolor mode. However, xterm.js doesn't handle this correctly, causing rendering issues like gray/white backgrounds appearing where they shouldn't.

## Solution
Unset `COLORTERM` in the environment when spawning PTY processes so applications fall back to standard 256-color mode which xterm.js fully supports.

## Changes
- `screen-manager.ts`: Add `unset COLORTERM` to screen session environment
- `session.ts`: Add `COLORTERM: undefined` to all PTY spawn env objects

## Related
- https://github.com/xtermjs/xterm.js/issues/484

🤖 Generated with [Claude Code](https://claude.ai/claude-code)