### PR TITLE
fix: resolve posix_spawnp and nested session spawn failures on macOS

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -6,9 +6,10 @@
  */
 
 import { execSync } from 'child_process';
-import { existsSync } from 'fs';
+import { chmodSync, existsSync } from 'fs';
 import { homedir, platform } from 'os';
-import { join } from 'path';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 // ============================================================================
 // Configuration
@@ -95,6 +96,26 @@ function getTmuxInstallInstructions() {
 
 console.log(colors.bold('Claudeman postinstall check...'));
 console.log('');
+
+// ----------------------------------------------------------------------------
+// 0. Fix node-pty spawn-helper permissions (required on macOS/Linux)
+// ----------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const spawnHelperPaths = [
+    join(__dirname, '..', 'node_modules', 'node-pty', 'prebuilds', 'darwin-arm64', 'spawn-helper'),
+    join(__dirname, '..', 'node_modules', 'node-pty', 'prebuilds', 'darwin-x64', 'spawn-helper'),
+];
+
+for (const helperPath of spawnHelperPaths) {
+    if (existsSync(helperPath)) {
+        try {
+            chmodSync(helperPath, 0o755);
+        } catch {
+            // Non-critical on platforms where this path doesn't apply
+        }
+    }
+}
 
 let hasWarnings = false;
 let hasErrors = false;

--- a/src/session.ts
+++ b/src/session.ts
@@ -868,7 +868,7 @@ export class Session extends EventEmitter {
             cols: 120,
             rows: 40,
             cwd: this.workingDir,
-            env: { ...process.env, TERM: 'xterm-256color' },
+            env: (() => { const e: Record<string, string | undefined> = { ...process.env, TERM: 'xterm-256color' }; delete e.CLAUDECODE; return e; })(),
           });
 
           // Set claudeSessionId immediately since we passed --session-id to Claude
@@ -934,15 +934,18 @@ export class Session extends EventEmitter {
           cols: 120,
           rows: 40,
           cwd: this.workingDir,
-          env: {
-            ...process.env,
-            PATH: getAugmentedPath(),
-            TERM: 'xterm-256color',
-            // Inform Claude it's running within Claudeman (helps prevent self-termination)
-            CLAUDEMAN_SCREEN: '1',
-            CLAUDEMAN_SESSION_ID: this.id,
-            CLAUDEMAN_API_URL: process.env.CLAUDEMAN_API_URL || 'http://localhost:3000',
-          },
+          env: (() => {
+            const env: Record<string, string | undefined> = {
+              ...process.env,
+              PATH: getAugmentedPath(),
+              TERM: 'xterm-256color',
+              CLAUDEMAN_SCREEN: '1',
+              CLAUDEMAN_SESSION_ID: this.id,
+              CLAUDEMAN_API_URL: process.env.CLAUDEMAN_API_URL || 'http://localhost:3000',
+            };
+            delete env.CLAUDECODE;
+            return env;
+          })(),
         });
       } catch (spawnErr) {
         console.error('[Session] Failed to spawn Claude PTY:', spawnErr);
@@ -1146,7 +1149,7 @@ export class Session extends EventEmitter {
             cols: 120,
             rows: 40,
             cwd: this.workingDir,
-            env: { ...process.env, TERM: 'xterm-256color' },
+            env: (() => { const e: Record<string, string | undefined> = { ...process.env, TERM: 'xterm-256color' }; delete e.CLAUDECODE; return e; })(),
           });
         } catch (spawnErr) {
           console.error('[Session] Failed to spawn PTY for shell mux attachment:', spawnErr);

--- a/src/tmux-manager.ts
+++ b/src/tmux-manager.ts
@@ -256,6 +256,7 @@ export class TmuxManager extends EventEmitter implements TerminalMultiplexer {
     const pathExport = claudeDir ? `export PATH="${claudeDir}:$PATH" && ` : '';
 
     const envExports = [
+      'unset CLAUDECODE',
       'export CLAUDEMAN_SCREEN=1',
       `export CLAUDEMAN_SESSION_ID=${sessionId}`,
       `export CLAUDEMAN_SCREEN_NAME=${muxName}`,


### PR DESCRIPTION
## Summary

Two issues prevent Claude from spawning in certain environments on macOS:

- **`posix_spawnp failed`**: `node-pty`'s `spawn-helper` prebuild binary loses its execute permission during `npm install`, causing every `pty.spawn()` call to fail. Fixed by adding `chmod +x` in `postinstall.js` for the darwin prebuilds.

- **`CLAUDECODE` env var leak**: When Claudeman is launched from within an existing Claude Code session (e.g. via Claude Code's Bash tool), the `CLAUDECODE=1` environment variable propagates into tmux and direct PTY child processes. Claude CLI detects this and refuses to start with _"cannot be launched inside another Claude Code session"_. Fixed by unsetting `CLAUDECODE` in both the tmux session command and the direct PTY `env` object.

## Changes

- `scripts/postinstall.js` — chmod `spawn-helper` prebuilds to `755` after install
- `src/tmux-manager.ts` — prepend `unset CLAUDECODE` to tmux session env exports
- `src/session.ts` — delete `CLAUDECODE` from env passed to `pty.spawn()` in all three spawn paths (tmux attach, direct PTY, shell mux attach)

## Test plan

- [x] Verified `npm run build` passes
- [x] Verified `claudeman web` starts and sessions spawn Claude successfully after fix
- [x] Tested on macOS arm64 (Darwin 25.2.0, Node 25.2.1)