### PR TITLE
fix: Modal CSS padding and width fixes (#7)

### DIFF
--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -2702,7 +2702,7 @@ body {
   justify-content: flex-end;
   gap: 0.5rem;
   margin-top: 1rem;
-  padding-top: 0.75rem;
+  padding: 0.75rem;
   border-top: 1px solid var(--border);
 }
 
@@ -2763,7 +2763,7 @@ body {
 }
 
 .modal-content.modal-lg {
-  max-width: 520px;
+  max-width: 540px;
   max-height: 85vh;
   display: flex;
   flex-direction: column;
@@ -3474,7 +3474,7 @@ body {
 .modal-tabs {
   display: flex;
   gap: 0.5rem;
-  padding: 0 1rem 0.75rem 1rem;
+  padding: 0.75rem;
   border-bottom: 1px solid var(--border);
 }
 


### PR DESCRIPTION
## Summary
- Change `.form-actions` from `padding-top: 0.75rem` to `padding: 0.75rem` for consistent button area spacing
- Increase `.modal-lg` max-width from `520px` to `540px` for better content fit
- Normalize `.modal-tabs` padding to uniform `0.75rem` instead of asymmetric values

Fixes #7

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Modal save/cancel buttons have consistent padding on all sides
- [ ] Large modals (Session Options) have slightly more horizontal room
- [ ] Modal tab buttons have uniform padding
- [ ] No visual regressions on mobile modal layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)