### PR TITLE
feat: Folder name in tabs + editable session name (#8)

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -533,6 +533,13 @@
 
           <!-- Context Management Tab Content -->
           <div class="modal-tab-content hidden" id="context-tab">
+            <div class="form-section-header">Session</div>
+            <div class="form-row">
+              <label for="modalSessionName">Session Name</label>
+              <input type="text" id="modalSessionName" placeholder="Auto (folder name)" onblur="app.saveSessionNameFromModal()">
+              <span class="form-hint">Custom name shown in the tab. Leave empty to use folder name.</span>
+            </div>
+
             <div class="form-section-header">Appearance</div>
             <div class="form-row">
               <label>Session Color</label>

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -197,8 +197,9 @@ body {
 
 .session-tab {
   display: flex;
-  align-items: center;
-  gap: 0.35rem;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.15rem;
   padding: 0.35rem 0.5rem;
   background: transparent;
   border: 1px solid transparent;
@@ -278,6 +279,34 @@ body {
 .session-tab .tab-name {
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.session-tab .tab-row-header {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.session-tab .tab-actions-inline {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  margin-left: auto;
+}
+
+.session-tab .tab-folder {
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  opacity: 0.7;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 120px;
+}
+
+.session-tab .tab-folder-icon {
+  font-size: 0.6rem;
+  margin-right: 0.15rem;
 }
 
 .session-tab .tab-close {
@@ -8339,6 +8368,8 @@ kbd {
     font-size: 0.7rem;
     gap: 0.25rem;
     border-radius: 4px;
+    flex-direction: row;
+    align-items: center;
   }
 
   /* Smaller status indicator on mobile */
@@ -8352,6 +8383,11 @@ kbd {
     max-width: 50px;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  /* Hide folder info on mobile */
+  .session-tab .tab-folder {
+    display: none;
   }
 
   /* Hide close/gear buttons on non-active tabs on mobile */


### PR DESCRIPTION
## Summary
- Restructure session tabs to two-row layout: top row has status/name/actions, bottom row shows working directory folder name
- Folder name displays with 📁 icon and tooltip showing full path
- Folder row hidden on mobile for compact display
- Add "Session Name" input field in the Context tab of Session Options modal
- Auto-saves on blur using the existing `PUT /api/sessions/:id/name` endpoint
- Right-click inline rename still works as before

Fixes #8

### Changes
**styles.css:**
- `.session-tab`: changed to `flex-direction: column` layout
- New classes: `.tab-row-header`, `.tab-actions-inline`, `.tab-folder`, `.tab-folder-icon`
- Mobile: `.tab-folder { display: none }` + revert to row layout

**app.js:**
- `_fullRenderSessionTabs()`: restructured tab HTML with `tab-row-header` wrapper and `tab-folder` span
- `openSessionOptions()`: populates `modalSessionName` input with current name
- New `saveSessionNameFromModal()`: saves name via PUT API on input blur

**index.html:**
- Added Session Name input field before Appearance section in Context tab

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Session tabs show folder name below session name
- [ ] Folder tooltip shows full working directory path
- [ ] Session Name input appears in Context tab of Session Options
- [ ] Editing session name and blurring saves automatically
- [ ] Clearing session name reverts tab to folder name display
- [ ] Right-click inline rename still works on tabs
- [ ] Mobile: folder row is hidden, tabs remain compact
- [ ] No visual regressions with subagent badges and task badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)