### PR TITLE
fix: CJK/Unicode wide character support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudeman",
-  "version": "0.1580",
+  "version": "0.1584",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudeman",
-      "version": "0.1580",
+      "version": "0.1584",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -20,6 +20,7 @@
         "uuid": "^10.0.0",
         "xterm": "^5.3.0",
         "xterm-addon-fit": "^0.8.0",
+        "xterm-addon-unicode11": "^0.6.0",
         "xterm-addon-webgl": "^0.16.0",
         "zod": "^4.3.6"
       },
@@ -4858,6 +4859,16 @@
       "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz",
       "integrity": "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==",
       "deprecated": "This package is now deprecated. Move to @xterm/addon-fit instead.",
+      "license": "MIT",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
+      }
+    },
+    "node_modules/xterm-addon-unicode11": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-unicode11/-/xterm-addon-unicode11-0.6.0.tgz",
+      "integrity": "sha512-5pkb8YoS/deRtNqQRw8t640mu+Ga8B2MG3RXGQu0bwgcfr8XiXIRI880TWM49ICAHhTmnOLPzIIBIjEnCq7k2A==",
+      "deprecated": "This package is now deprecated. Move to @xterm/addon-unicode11 instead.",
       "license": "MIT",
       "peerDependencies": {
         "xterm": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.js",
-    "build": "tsc && chmod +x dist/index.js && mkdir -p dist/web dist/templates dist/web/public/vendor && cp -r src/web/public dist/web/ && cp src/templates/case-template.md dist/templates/ && cp node_modules/xterm/css/xterm.css dist/web/public/vendor/ && npx esbuild node_modules/xterm/lib/xterm.js --minify --outfile=dist/web/public/vendor/xterm.min.js && npx esbuild node_modules/xterm-addon-fit/lib/xterm-addon-fit.js --minify --outfile=dist/web/public/vendor/xterm-addon-fit.min.js && cp node_modules/xterm-addon-webgl/lib/xterm-addon-webgl.js dist/web/public/vendor/xterm-addon-webgl.min.js && npx esbuild dist/web/public/app.js --minify --drop:console --outfile=dist/web/public/app.js --allow-overwrite && npx esbuild dist/web/public/styles.css --minify --outfile=dist/web/public/styles.css --allow-overwrite && npx esbuild dist/web/public/mobile.css --minify --outfile=dist/web/public/mobile.css --allow-overwrite && for f in dist/web/public/*.js dist/web/public/*.css dist/web/public/*.html dist/web/public/vendor/*.js dist/web/public/vendor/*.css; do [ -f \"$f\" ] && gzip -9 -k -f \"$f\" && { brotli -9 -k -f \"$f\" 2>/dev/null || true; }; done",
+    "build": "tsc && chmod +x dist/index.js && mkdir -p dist/web dist/templates dist/web/public/vendor && cp -r src/web/public dist/web/ && cp src/templates/case-template.md dist/templates/ && cp node_modules/xterm/css/xterm.css dist/web/public/vendor/ && npx esbuild node_modules/xterm/lib/xterm.js --minify --outfile=dist/web/public/vendor/xterm.min.js && npx esbuild node_modules/xterm-addon-fit/lib/xterm-addon-fit.js --minify --outfile=dist/web/public/vendor/xterm-addon-fit.min.js && cp node_modules/xterm-addon-webgl/lib/xterm-addon-webgl.js dist/web/public/vendor/xterm-addon-webgl.min.js && npx esbuild node_modules/xterm-addon-unicode11/lib/xterm-addon-unicode11.js --minify --outfile=dist/web/public/vendor/xterm-addon-unicode11.min.js && npx esbuild dist/web/public/app.js --minify --drop:console --outfile=dist/web/public/app.js --allow-overwrite && npx esbuild dist/web/public/styles.css --minify --outfile=dist/web/public/styles.css --allow-overwrite && npx esbuild dist/web/public/mobile.css --minify --outfile=dist/web/public/mobile.css --allow-overwrite && for f in dist/web/public/*.js dist/web/public/*.css dist/web/public/*.html dist/web/public/vendor/*.js dist/web/public/vendor/*.css; do [ -f \"$f\" ] && gzip -9 -k -f \"$f\" && { brotli -9 -k -f \"$f\" 2>/dev/null || true; }; done",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
     "web": "node dist/index.js web",
@@ -47,6 +47,7 @@
     "uuid": "^10.0.0",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",
+    "xterm-addon-unicode11": "^0.6.0",
     "xterm-addon-webgl": "^0.16.0",
     "zod": "^4.3.6"
   },

--- a/src/session.ts
+++ b/src/session.ts
@@ -902,7 +902,7 @@ export class Session extends EventEmitter {
             cols: 120,
             rows: 40,
             cwd: this.workingDir,
-            env: { ...process.env, TERM: 'xterm-256color', COLORTERM: undefined, CLAUDECODE: undefined },
+            env: { ...process.env, LANG: 'en_US.UTF-8', LC_ALL: 'en_US.UTF-8', TERM: 'xterm-256color', COLORTERM: undefined, CLAUDECODE: undefined },
           });
 
           // Set claudeSessionId immediately since we passed --session-id to Claude
@@ -969,6 +969,8 @@ export class Session extends EventEmitter {
           cwd: this.workingDir,
           env: {
             ...process.env,
+            LANG: 'en_US.UTF-8',
+            LC_ALL: 'en_US.UTF-8',
             PATH: getAugmentedPath(),
             TERM: 'xterm-256color',
             COLORTERM: undefined,
@@ -1251,7 +1253,7 @@ export class Session extends EventEmitter {
             cols: 120,
             rows: 40,
             cwd: this.workingDir,
-            env: { ...process.env, TERM: 'xterm-256color', COLORTERM: undefined, CLAUDECODE: undefined },
+            env: { ...process.env, LANG: 'en_US.UTF-8', LC_ALL: 'en_US.UTF-8', TERM: 'xterm-256color', COLORTERM: undefined, CLAUDECODE: undefined },
           });
         } catch (spawnErr) {
           console.error('[Session] Failed to spawn PTY for shell mux attachment:', spawnErr);
@@ -1286,6 +1288,8 @@ export class Session extends EventEmitter {
           cwd: this.workingDir,
           env: {
             ...process.env,
+            LANG: 'en_US.UTF-8',
+            LC_ALL: 'en_US.UTF-8',
             TERM: 'xterm-256color',
             CLAUDEMAN_MUX: '1',
             CLAUDEMAN_SESSION_ID: this.id,
@@ -1414,6 +1418,8 @@ export class Session extends EventEmitter {
             cwd: this.workingDir,
             env: {
               ...process.env,
+              LANG: 'en_US.UTF-8',
+              LC_ALL: 'en_US.UTF-8',
               PATH: getAugmentedPath(),
               TERM: 'xterm-256color',
               COLORTERM: undefined,

--- a/src/tmux-manager.ts
+++ b/src/tmux-manager.ts
@@ -231,6 +231,8 @@ export class TmuxManager extends EventEmitter implements TerminalMultiplexer {
     const pathExport = claudeDir ? `export PATH="${claudeDir}:$PATH" && ` : '';
 
     const envExports = [
+      'export LANG=en_US.UTF-8',
+      'export LC_ALL=en_US.UTF-8',
       'unset CLAUDECODE',
       'unset COLORTERM',
       'export CLAUDEMAN_MUX=1',
@@ -392,6 +394,8 @@ export class TmuxManager extends EventEmitter implements TerminalMultiplexer {
     const claudeDir = findClaudeDir();
     const pathExport = claudeDir ? `export PATH="${claudeDir}:$PATH" && ` : '';
     const envExports = [
+      'export LANG=en_US.UTF-8',
+      'export LC_ALL=en_US.UTF-8',
       'unset CLAUDECODE',
       'unset COLORTERM',
       'export CLAUDEMAN_MUX=1',

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -8,8 +8,8 @@
   <meta name="google" content="notranslate">
   <title>Claudeman</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%2360a5fa'/%3E%3Cstop offset='100%25' stop-color='%233b82f6'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='32' height='32' rx='6' fill='%230a0a0a'/%3E%3Cpath d='M18 4L8 18h6l-2 10 10-14h-6z' fill='url(%23g)'/%3E%3C/svg%3E">
-  <link rel="stylesheet" href="styles.css?v=0.1578">
-  <link rel="stylesheet" href="mobile.css?v=0.1578" media="(max-width: 1023px)">
+  <link rel="stylesheet" href="styles.css?v=0.1584">
+  <link rel="stylesheet" href="mobile.css?v=0.1584" media="(max-width: 1023px)">
   <!-- xterm.css loaded async — terminal won't display until xterm.js runs anyway -->
   <link rel="preload" href="vendor/xterm.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="vendor/xterm.css"></noscript>
@@ -18,6 +18,7 @@
   <script defer src="vendor/xterm.min.js"></script>
   <script defer src="vendor/xterm-addon-fit.min.js"></script>
   <script defer src="vendor/xterm-addon-webgl.min.js"></script>
+  <script defer src="vendor/xterm-addon-unicode11.min.js"></script>
   <!-- Synchronous mobile detection — runs before first paint to prevent panel flash -->
   <script>if(window.innerWidth<768||(('ontouchstart' in window||navigator.maxTouchPoints>0)&&window.innerWidth<1024))document.documentElement.classList.add('mobile-init');</script>
   <!-- Inline critical CSS for instant skeleton paint (before styles.css loads) -->
@@ -1559,6 +1560,6 @@
     <!-- Lines drawn dynamically -->
   </svg>
 
-  <script defer src="app.js?v=0.1578"></script>
+  <script defer src="app.js?v=0.1584"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **Set UTF-8 locale** (`LANG=en_US.UTF-8`, `LC_ALL=en_US.UTF-8`) in all PTY spawn environments — tmux sessions, direct PTY (claude/shell), and runPrompt. Without this, sessions inherit `C` locale which breaks CJK text handling in programs like ncurses, readline, etc.
- **Add `xterm-addon-unicode11`** for proper CJK double-width character measurement in the xterm.js browser terminal
- **Fix `LocalEchoOverlay`** to respect character visual width — CJK characters now correctly occupy 2 cell widths in character positioning, line wrapping, and cursor placement. Previously all characters were assumed to be 1 cell wide, causing Chinese/Japanese/Korean text to overlap during input.
- **Bump asset version** query strings to `0.1584` for cache invalidation (static files use `immutable` caching)

## Files Changed

| File | Change |
|------|--------|
| `src/tmux-manager.ts` | Add `LANG`/`LC_ALL` exports to tmux session env (2 locations) |
| `src/session.ts` | Add `LANG`/`LC_ALL` to all 5 `pty.spawn()` env objects |
| `src/web/public/app.js` | Add `_charCellWidth`/`_stringCellWidth` helpers; fix `_makeLine`, `_render`, cursor positioning; load Unicode11 addon for main + teammate terminals |
| `src/web/public/index.html` | Add unicode11 addon script tag; bump `?v=` to `0.1584` |
| `package.json` | Add `xterm-addon-unicode11@0.6.0` dependency + build step |

## Test plan

- [ ] Open Claudeman web UI, create a new session
- [ ] Verify `locale` command shows `en_US.UTF-8` inside the session
- [ ] Type Chinese text (e.g., via pinyin IME) — characters should not overlap during input
- [ ] Verify CJK text renders with correct double-width spacing after submission
- [ ] Test Japanese (こんにちは) and Korean (안녕하세요) input
- [ ] Verify existing ASCII input is unaffected
- [ ] Test teammate terminal panels also render CJK correctly