### PR TITLE
feat: enhanced Monitor panel + Linux/WSL compatibility fixes

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -8,8 +8,8 @@
   <meta name="google" content="notranslate">
   <title>Claudeman</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%2360a5fa'/%3E%3Cstop offset='100%25' stop-color='%233b82f6'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='32' height='32' rx='6' fill='%230a0a0a'/%3E%3Cpath d='M18 4L8 18h6l-2 10 10-14h-6z' fill='url(%23g)'/%3E%3C/svg%3E">
-  <link rel="stylesheet" href="styles.css?v=0.1597">
-  <link rel="stylesheet" href="mobile.css?v=0.1597" media="(max-width: 1023px)">
+  <link rel="stylesheet" href="styles.css?v=0.1608">
+  <link rel="stylesheet" href="mobile.css?v=0.1608" media="(max-width: 1023px)">
   <!-- xterm.css loaded async — terminal won't display until xterm.js runs anyway -->
   <link rel="preload" href="vendor/xterm.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="vendor/xterm.css"></noscript>
@@ -1559,6 +1559,6 @@
     <!-- Lines drawn dynamically -->
   </svg>
 
-  <script defer src="app.js?v=0.1597"></script>
+  <script defer src="app.js?v=0.1608"></script>
 </body>
 </html>

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -4291,6 +4291,53 @@ kbd {
   color: var(--yellow);
 }
 
+/* Monitor status badges */
+.monitor-status-badge {
+  font-size: 0.55rem;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+  min-width: 52px;
+  text-align: center;
+}
+.monitor-status-badge.status-idle {
+  background: rgba(234, 179, 8, 0.2);
+  color: var(--yellow);
+}
+.monitor-status-badge.status-working {
+  background: rgba(74, 222, 128, 0.2);
+  color: var(--green);
+  animation: pulse-working 2s ease-in-out infinite;
+}
+.monitor-status-badge.status-stopped {
+  background: rgba(239, 68, 68, 0.2);
+  color: var(--red, #ef4444);
+}
+@keyframes pulse-working {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+/* Monitor model badges */
+.monitor-model-badge {
+  font-size: 0.55rem;
+  padding: 1px 4px;
+  border-radius: 2px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.monitor-model-badge.opus { background: rgba(168, 85, 247, 0.2); color: #c084fc; }
+.monitor-model-badge.sonnet { background: rgba(59, 130, 246, 0.2); color: #60a5fa; }
+.monitor-model-badge.haiku { background: rgba(74, 222, 128, 0.2); color: #4ade80; }
+
+/* Monitor stat colors */
+.process-stat.tokens { color: var(--accent-hover); }
+.process-stat.cost { color: #f59e0b; }
+.process-stat.todo-progress { color: #c084fc; }
+
 /* Combined Monitor Panel (Tmux Sessions + Background Tasks) */
 .monitor-panel {
   position: fixed;


### PR DESCRIPTION
## Summary
- **Monitor panel now shows session status**: IDLE/WORKING/STOPPED badges per session (data was already available server-side via `session:updated` SSE events but not surfaced in the Monitor UI)
- **Added token count, cost, model badge** (opus/sonnet/haiku), and todo progress to Monitor panel
- **Kill from Monitor now properly removes the session tab** — previously killing from Monitor left stale tabs that required manual cleanup
- **Fixed `sed -i` for Linux/WSL** — removed macOS-only `''` argument that caused `sed: can't read` errors on Linux

## Test plan
- [ ] Verify Monitor panel shows IDLE/WORKING/STOPPED status for active sessions
- [ ] Verify token count, cost, and model badges appear in Monitor
- [ ] Verify killing a session from Monitor removes both the mux session and the tab
- [ ] Verify `sed -i` works on both macOS and Linux (agent spawning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)