### PR TITLE
Fix quick-start to resolve linked cases before codeman-cases fallback

### DIFF
--- a/src/web/routes/session-routes.ts
+++ b/src/web/routes/session-routes.ts
@@ -6,6 +6,7 @@
 
 import { FastifyInstance } from 'fastify';
 import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
 import { existsSync, statSync, mkdirSync, writeFileSync } from 'node:fs';
 import { execFile } from 'node:child_process';
 import fs from 'node:fs/promises';
@@ -52,6 +53,9 @@ import { MAX_CONCURRENT_SESSIONS } from '../../config/map-limits.js';
 import { RunSummaryTracker } from '../../run-summary.js';
 
 import { MAX_INPUT_LENGTH, MAX_SESSION_NAME_LENGTH } from '../../config/terminal-limits.js';
+
+// Path to linked-cases registry (same file used by case-routes resolveCasePath)
+const LINKED_CASES_FILE = join(homedir(), '.codeman', 'linked-cases.json');
 
 // Pre-compiled regex for terminal buffer cleaning (avoids per-request compilation)
 // eslint-disable-next-line no-control-regex
@@ -919,12 +923,23 @@ export function registerSessionRoutes(
       }
     }
 
-    const casePath = validatePathWithinBase(caseName, CASES_DIR);
+    // Resolve case path: check linked-cases registry first, then fall back to CASES_DIR.
+    // This mirrors the behaviour of resolveCasePath() in case-routes so that linked
+    // external project directories are honoured by quick-start just like regular case routes.
+    let linkedCases: Record<string, string> = {};
+    try {
+      const raw = await fs.readFile(LINKED_CASES_FILE, 'utf-8');
+      linkedCases = JSON.parse(raw);
+    } catch {
+      // File missing or unparseable — treat as empty registry
+    }
+    const linkedCasePath = linkedCases[caseName];
+    const casePath = linkedCasePath || validatePathWithinBase(caseName, CASES_DIR);
     if (!casePath) {
       return createErrorResponse(ApiErrorCode.INVALID_INPUT, 'Invalid case path');
     }
 
-    // Create case folder and CLAUDE.md if it doesn't exist
+    // Create case folder and CLAUDE.md if it doesn't exist (only for non-linked cases)
     if (!existsSync(casePath)) {
       try {
         mkdirSync(casePath, { recursive: true });
@@ -1098,7 +1113,7 @@ export function registerSessionRoutes(
           text.length < 8
         )
           continue;
-        return text.length > MAX_PROMPT_LEN ? text.slice(0, MAX_PROMPT_LEN) + '…' : text;
+        return text.length > MAX_PROMPT_LEN ? text.slice(0, MAX_PROMPT_LEN) + '\u2026' : text;
       } catch {
         // Malformed line — skip
       }


### PR DESCRIPTION
## Problem

`/api/quick-start` was always resolving `caseName` against `CASES_DIR` (`~/codeman-cases/`), completely ignoring entries in `~/.codeman/linked-cases.json`.

This meant that sessions started via quick-start would always open in `~/codeman-cases/<name>` even when the case was linked to an external project directory — while regular case routes (via `resolveCasePath()`) correctly honoured the linked-cases registry.

## Root cause

```ts
// Before — always resolves against CASES_DIR, never checks linked-cases
const casePath = validatePathWithinBase(caseName, CASES_DIR);
```

## Fix

- Added `import { homedir } from 'node:os'`
- Added a module-level `LINKED_CASES_FILE` constant pointing to `~/.codeman/linked-cases.json`
- In `/api/quick-start`, read `linked-cases.json` first and resolve `caseName` from it, falling back to `validatePathWithinBase(caseName, CASES_DIR)` only when no link exists

```ts
// After — mirrors the behaviour of resolveCasePath() in case-routes
let linkedCases: Record<string, string> = {};
try {
  const raw = await fs.readFile(LINKED_CASES_FILE, 'utf-8');
  linkedCases = JSON.parse(raw);
} catch {
  // File missing or unparseable — treat as empty registry
}
const linkedCasePath = linkedCases[caseName];
const casePath = linkedCasePath || validatePathWithinBase(caseName, CASES_DIR);
```

## Result

Quick-start now behaves consistently with regular case routes and correctly opens linked external project directories.