### PR TITLE
feat: add Ctrl+Shift+{/} to reorder session tabs

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -639,6 +639,8 @@ class CodemanApp {
       { key: '=', altKey: '+', ctrl: true, action: () => this.increaseFontSize() },
       { key: '-', ctrl: true, action: () => this.decreaseFontSize() },
       { key: 'V', ctrl: true, shift: true, action: () => VoiceInput.toggle() },
+      { key: '{', ctrl: true, shift: true, action: () => this.moveActiveTabLeft() },
+      { key: '}', ctrl: true, shift: true, action: () => this.moveActiveTabRight() },
     ];
 
     // Use capture to handle before terminal
@@ -2104,6 +2106,24 @@ class CodemanApp {
         this._fullRenderSessionTabs();
       });
     });
+  }
+
+  moveActiveTabLeft() {
+    if (!this.activeSessionId) return;
+    const idx = this.sessionOrder.indexOf(this.activeSessionId);
+    if (idx <= 0) return;
+    [this.sessionOrder[idx - 1], this.sessionOrder[idx]] = [this.sessionOrder[idx], this.sessionOrder[idx - 1]];
+    this.saveSessionOrder();
+    this._fullRenderSessionTabs();
+  }
+
+  moveActiveTabRight() {
+    if (!this.activeSessionId) return;
+    const idx = this.sessionOrder.indexOf(this.activeSessionId);
+    if (idx === -1 || idx >= this.sessionOrder.length - 1) return;
+    [this.sessionOrder[idx], this.sessionOrder[idx + 1]] = [this.sessionOrder[idx + 1], this.sessionOrder[idx]];
+    this.saveSessionOrder();
+    this._fullRenderSessionTabs();
   }
 
   // ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
Adds keyboard shortcuts to move the active session tab left or right, matching the convention used in WezTerm and other terminal emulators.

- **Ctrl+Shift+{** -- move active tab left
- **Ctrl+Shift+}** -- move active tab right

Uses the existing `sessionOrder` array and `saveSessionOrder()` for persistence.

## Test plan
- [ ] Ctrl+Shift+{ moves the active tab one position left
- [ ] Ctrl+Shift+} moves the active tab one position right
- [ ] Tab order persists across page refresh
- [ ] No-op at the edges (first tab can't go left, last can't go right)