### PR TITLE
fix: sync package-lock.json version with package.json (0.6.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aicodeman",
-  "version": "0.3.11",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aicodeman",
-      "version": "0.3.11",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [


### PR DESCRIPTION
`package.json` is at `0.6.0` but `package-lock.json` still has `0.3.11` in both the root and `packages[""]` entries. Running `npm install` regenerates the lockfile with this exact diff. Bumping the two fields directly so `npm ci` works against the committed state.