### PR TITLE
feat: thinking effort setting for new sessions (with xhigh/max)

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -1095,6 +1095,17 @@
               </label>
               <span class="form-hint">Use 1M token context window (model: opus[1m]) for all new sessions</span>
             </div>
+            <div class="form-row">
+              <label>Thinking Effort</label>
+              <select id="appSettingsThinkingEffort" class="form-select">
+                <option value="">Default</option>
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+                <option value="max">Max</option>
+              </select>
+              <span class="form-hint">Set CLAUDE_CODE_EFFORT_LEVEL for all new sessions (default = no override)</span>
+            </div>
             <!-- Nice Priority Section -->
             <div class="form-section-header">Nice Priority</div>
             <div class="form-row form-row-switch">

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -1102,6 +1102,7 @@
                 <option value="low">Low</option>
                 <option value="medium">Medium</option>
                 <option value="high">High</option>
+                <option value="xhigh">XHigh</option>
                 <option value="max">Max</option>
               </select>
               <span class="form-hint">Set CLAUDE_CODE_EFFORT_LEVEL for all new sessions (default = no override)</span>

--- a/src/web/public/keyboard-accessory.js
+++ b/src/web/public/keyboard-accessory.js
@@ -92,6 +92,7 @@ const KeyboardAccessoryBar = {
       </button>
       <button class="accessory-btn" data-action="tab" title="Tab">Tab</button>
       <button class="accessory-btn" data-action="shift-tab" title="Shift+Tab">⇧Tab</button>
+      <button class="accessory-btn" data-action="effort-max" title="/effort max">Max</button>
       <button class="accessory-btn" data-action="ctrl-o" title="Ctrl+O">⌃O</button>
       <button class="accessory-btn" data-action="opt-enter" title="Option+Enter (newline)">⌥Enter</button>
       <button class="accessory-btn" data-action="esc" title="Escape">Esc</button>
@@ -125,7 +126,7 @@ const KeyboardAccessoryBar = {
       this.handleAction(action, btn);
 
       // Refocus terminal so keyboard stays open (tap blurs terminal → keyboard dismisses → toolbar shifts)
-      const refocusActions = new Set(['scroll-up', 'scroll-down', 'arrow-left', 'arrow-right', 'tab', 'shift-tab', 'ctrl-o', 'opt-enter', 'esc']);
+      const refocusActions = new Set(['scroll-up', 'scroll-down', 'arrow-left', 'arrow-right', 'tab', 'shift-tab', 'ctrl-o', 'opt-enter', 'esc', 'effort-max']);
       if (refocusActions.has(action) ||
           ((action === 'clear' || action === 'compact') && this._confirmAction)) {
         if (typeof app !== 'undefined' && app.terminal) {
@@ -183,6 +184,9 @@ const KeyboardAccessoryBar = {
         break;
       case 'ctrl-o':
         this.sendKey('\x0f');
+        break;
+      case 'effort-max':
+        this.sendCommand('/effort max');
         break;
       case 'init':
         this.sendCommand('/init');

--- a/src/web/public/session-ui.js
+++ b/src/web/public/session-ui.js
@@ -323,6 +323,10 @@ Object.assign(CodemanApp.prototype, {
       if (caseSettings.agentTeams || globalSettings.agentTeamsEnabled) {
         envOverrides.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = '1';
       }
+      const thinkingEffort = globalSettings.thinkingEffort;
+      if (thinkingEffort) {
+        envOverrides.CLAUDE_CODE_EFFORT_LEVEL = thinkingEffort;
+      }
       const hasEnvOverrides = Object.keys(envOverrides).length > 0;
       const useOpus1m = caseSettings.opusContext1m || globalSettings.opusContext1mEnabled;
       const modelOverride = useOpus1m ? 'opus[1m]' : '';

--- a/src/web/public/settings-ui.js
+++ b/src/web/public/settings-ui.js
@@ -334,6 +334,7 @@ Object.assign(CodemanApp.prototype, {
     // Claude Permissions settings
     document.getElementById('appSettingsAgentTeams').checked = settings.agentTeamsEnabled ?? false;
     document.getElementById('appSettingsOpusContext1m').checked = settings.opusContext1mEnabled ?? false;
+    document.getElementById('appSettingsThinkingEffort').value = settings.thinkingEffort ?? '';
     // CPU Priority settings
     const niceSettings = settings.nice || {};
     document.getElementById('appSettingsNiceEnabled').checked = niceSettings.enabled ?? false;
@@ -1134,6 +1135,7 @@ Object.assign(CodemanApp.prototype, {
       // Claude Permissions settings
       agentTeamsEnabled: document.getElementById('appSettingsAgentTeams').checked,
       opusContext1mEnabled: document.getElementById('appSettingsOpusContext1m').checked,
+      thinkingEffort: document.getElementById('appSettingsThinkingEffort').value,
       // CPU Priority settings
       nice: {
         enabled: document.getElementById('appSettingsNiceEnabled').checked,

--- a/src/web/schemas.ts
+++ b/src/web/schemas.ts
@@ -267,6 +267,7 @@ export const SettingsUpdateSchema = z
     tunnelEnabled: z.boolean().optional(),
     tabTwoRows: z.boolean().optional(),
     agentTeamsEnabled: z.boolean().optional(),
+    thinkingEffort: z.string().max(20).optional(),
     // UI visibility
     showFontControls: z.boolean().optional(),
     showSystemStats: z.boolean().optional(),


### PR DESCRIPTION
## Summary
Two related commits:

1. **Thinking effort setting** — new "Thinking Effort" select in app settings (`low` / `medium` / `high`) that sets `CLAUDE_CODE_EFFORT_LEVEL` for all newly created sessions. Surfaces via `settings-ui.js` and is passed through `session-ui.js` into the CLI env.
2. **Extended levels + mobile shortcut** — add `xhigh` and `max` options to the same select, plus a `Max` button in the mobile keyboard accessory bar that sends `/effort max` to the active Claude session so you can bump effort without typing on mobile.

## Test plan
- [x] Settings panel shows Thinking Effort dropdown with `low/medium/high/xhigh/max` + Default
- [x] New session spawned with non-Default level exports `CLAUDE_CODE_EFFORT_LEVEL`
- [x] Mobile keyboard accessory bar has `Max` button that sends `/effort max`
- [x] `npm run typecheck` / `npm run lint` / `npm run build` pass