### PR TITLE
fix: last-response viewer follows /clear to the new Claude conversation

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -473,6 +473,15 @@ export class Session extends EventEmitter {
     return this._claudeSessionId;
   }
 
+  // Adopt a Claude conversation ID observed from an external source (e.g. hook
+  // payload). In interactive PTY mode Claude CLI emits no JSON to stdout, so
+  // `_handleJsonMessage` never sees `session_id`; hooks are the only signal
+  // that conveys a post-/clear conversation switch.
+  adoptClaudeSessionId(newId: string): void {
+    if (!newId || newId === this._claudeSessionId) return;
+    this._claudeSessionId = newId;
+  }
+
   /** The tmux session name, if the session is running inside a mux */
   get muxName(): string | null {
     return this._muxSession?.muxName ?? null;

--- a/src/web/routes/hook-event-routes.ts
+++ b/src/web/routes/hook-event-routes.ts
@@ -43,6 +43,14 @@ export function registerHookEventRoutes(
       }
     }
 
+    // Sync Claude's current conversation id. Interactive PTY mode never emits
+    // `session_id` on stdout, so hooks are the only reliable way to learn that
+    // the user ran `/clear` (which spins up a new conversation jsonl).
+    if (data && typeof data.session_id === 'string' && data.session_id) {
+      const session = ctx.sessions.get(sessionId);
+      session?.adoptClaudeSessionId(data.session_id);
+    }
+
     // Sanitize forwarded data: only include known safe fields, limit size
     const safeData = sanitizeHookData(data);
     ctx.broadcast(`hook:${event}`, { sessionId, timestamp: Date.now(), ...safeData });

--- a/src/web/routes/session-routes.ts
+++ b/src/web/routes/session-routes.ts
@@ -582,15 +582,99 @@ export function registerSessionRoutes(
 
   // ========== Get Last Response (from transcript JSONL) ==========
 
+  // Resolves the most recent Claude conversation id for a session's cwd by
+  // tailing ~/.claude/history.jsonl. After `/clear`, Claude Code keeps writing
+  // to a new <uuid>.jsonl; history.jsonl is the only source-of-truth update
+  // that does not rely on project-local hooks (we intentionally don't install
+  // hooks in arbitrary user repos, see the POST /api/sessions comment).
+  //
+  // Entries from OTHER Codeman sessions in the same cwd are filtered out by
+  // their known claudeSessionIds so concurrent tabs don't shadow each other,
+  // as long as each has had its id resolved at least once.
+  async function resolveActiveClaudeSessionIdFromHistory(
+    session: Session,
+    projectsDir: string
+  ): Promise<string | null> {
+    const historyPath = join(homedir(), '.claude', 'history.jsonl');
+    const otherClaudeIds = new Set<string>();
+    for (const s of ctx.sessions.values()) {
+      if (s.id !== session.id && s.workingDir === session.workingDir && s.claudeSessionId) {
+        otherClaudeIds.add(s.claudeSessionId);
+      }
+    }
+
+    let candidateSid: string | null = null;
+    try {
+      const content = await fs.readFile(historyPath, 'utf8');
+      const lines = content.split('\n');
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i];
+        if (!line) continue;
+        try {
+          const entry = JSON.parse(line) as { project?: string; sessionId?: string };
+          if (
+            entry.project === session.workingDir &&
+            typeof entry.sessionId === 'string' &&
+            !otherClaudeIds.has(entry.sessionId)
+          ) {
+            candidateSid = entry.sessionId;
+            break;
+          }
+        } catch {
+          // Skip unparseable lines
+        }
+      }
+    } catch {
+      return null;
+    }
+    if (!candidateSid || candidateSid === session.id) return candidateSid;
+
+    // Safety: only adopt if the candidate's jsonl is more recently written
+    // than our initial conversation's jsonl. Blocks stale ids inherited from
+    // a prior Codeman session that happened to share this cwd.
+    try {
+      const projectDirs = await fs.readdir(projectsDir);
+      let candidateMtime = 0;
+      let initialMtime = 0;
+      for (const projDir of projectDirs) {
+        try {
+          const cs = await fs.stat(join(projectsDir, projDir, `${candidateSid}.jsonl`));
+          if (cs.mtimeMs > candidateMtime) candidateMtime = cs.mtimeMs;
+        } catch {
+          /* not in this dir */
+        }
+        try {
+          const is = await fs.stat(join(projectsDir, projDir, `${session.id}.jsonl`));
+          if (is.mtimeMs > initialMtime) initialMtime = is.mtimeMs;
+        } catch {
+          /* not in this dir */
+        }
+      }
+      if (candidateMtime === 0) return null;
+      if (initialMtime > 0 && candidateMtime <= initialMtime) return null;
+    } catch {
+      return null;
+    }
+    return candidateSid;
+  }
+
   app.get('/api/sessions/:id/last-response', async (req) => {
     const { id } = req.params as { id: string };
     const session = findSessionOrFail(ctx, id);
 
-    // The Claude conversation ID (used as JSONL filename)
-    const claudeSessionId = session.claudeSessionId || session.id;
-
     // Scan ~/.claude/projects/*/ for the transcript file
     const projectsDir = join(process.env.HOME || '/tmp', '.claude', 'projects');
+
+    // Adopt the current conversation id if the user ran `/clear` — Claude CLI's
+    // interactive PTY emits no JSON on stdout, so without this lookup the
+    // stored id stays pinned to the pre-/clear transcript.
+    const activeId = await resolveActiveClaudeSessionIdFromHistory(session, projectsDir);
+    if (activeId && activeId !== session.claudeSessionId) {
+      session.adoptClaudeSessionId(activeId);
+    }
+
+    // The Claude conversation ID (used as JSONL filename)
+    const claudeSessionId = session.claudeSessionId || session.id;
     let transcriptText = '';
     let transcriptTimestamp = '';
 


### PR DESCRIPTION
## Summary

The last-response viewer (eye icon) keeps showing the pre-/clear transcript after a user runs `/clear` in the Claude CLI. This is because the Session's `_claudeSessionId` is only refreshed when Claude emits JSON on stdout, which never happens in the interactive PTY mode Codeman spawns.

This PR adds two complementary update paths:

- **`Session.adoptClaudeSessionId()`** — public setter mirroring the existing no-op-if-same guard. Called from `POST /api/hook-event` whenever Claude Code hooks carry `data.session_id` (works automatically once hooks are configured in the target case).

- **`/api/sessions/:id/last-response`** now resolves the active conversation id from `~/.claude/history.jsonl` before reading the transcript. This is the only source-of-truth that does not require hooks, which matters because Codeman intentionally does not write hook config into arbitrary user repos (see the comment at `session-routes.ts` `POST /api/sessions`).

The history scan:
- Skips entries held by other Codeman sessions in the same cwd so concurrent tabs don't shadow each other.
- Requires the candidate's jsonl mtime to exceed the initial `<session.id>.jsonl` mtime, so a stale id inherited from a prior dead session is never adopted.

## Why history.jsonl

Claude Code writes one line per user prompt to `~/.claude/history.jsonl` with `{sessionId, project, timestamp}`. After `/clear` the new conversation uuid shows up there on the first prompt. `~/.claude/sessions/<pid>.json` would be nicer but older Claude CLI versions don't update it after `/clear`, so it isn't reliable across versions.

## Test plan

- [x] Verified against a session that had been `/clear`ed: `claudeSessionId` adopts the post-/clear uuid on the next eye-icon request, and the returned transcript reflects the new conversation.
- [x] Verified non-cleared sessions are unaffected (`claudeSessionId` stays equal to `session.id`).
- [x] Synthetic hook POST with a fake `session_id` flips `claudeSessionId` and a follow-up POST with the original id restores it.
- [x] `tsc --noEmit` clean, `npm run build` succeeds.

## Known limitation

If two concurrent Codeman sessions in the same cwd both run `/clear` before either has had its id re-resolved, the history scan can't disambiguate them (history.jsonl doesn't record which Codeman session typed). Single-session `/clear` and single-tab-per-cwd setups are unaffected.