### PR TITLE
fix: allowlist opusContext1mEnabled in SettingsUpdateSchema

### DIFF
--- a/src/web/schemas.ts
+++ b/src/web/schemas.ts
@@ -267,6 +267,7 @@ export const SettingsUpdateSchema = z
     tunnelEnabled: z.boolean().optional(),
     tabTwoRows: z.boolean().optional(),
     agentTeamsEnabled: z.boolean().optional(),
+    opusContext1mEnabled: z.boolean().optional(),
     thinkingEffort: z.string().max(20).optional(),
     // UI visibility
     showFontControls: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- Adds `opusContext1mEnabled: z.boolean().optional()` to `SettingsUpdateSchema`. Without it, `PUT /api/settings` rejects the field (the schema is `.strict()`) and the toggle's value never persists across reloads.

## Context
Same root cause as the `thinkingEffort` fix in #73. Discovered while reviewing that PR — verified live against the running server:
- Pre-fix: `PUT /api/settings {"opusContext1mEnabled":true}` → `{"success":false,"error":"Invalid settings","errorCode":"INVALID_INPUT"}`
- Post-fix: accepts and persists.

The frontend has been reading and writing this key for a while (`settings-ui.js:336`, `:1137`; `session-ui.js:331`), so saves were silently failing — users never noticed because the load path falls back to `false` on missing keys, hiding the bug.

## Test plan
- [x] Schema unit-test: `safeParse({opusContext1mEnabled: true})` succeeds; bad type rejected
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [ ] After deploy: verify toggle persists across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)