### PR TITLE
fix: prevent tmux flicker on restart by matching existing window size

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -29,7 +29,7 @@
  */
 
 import { EventEmitter } from 'node:events';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { v4 as uuidv4 } from 'uuid';
 import * as pty from 'node-pty';
 import {
@@ -946,11 +946,28 @@ export class Session extends EventEmitter {
     }
 
     // Attach to the mux session via PTY
+    // Query existing tmux window size so re-attach matches (avoids flicker from 120x40 default)
+    let ptyCols = 120;
+    let ptyRows = 40;
+    try {
+      const sizeStr = execFileSync(
+        'tmux',
+        ['display', '-t', this._muxSession!.muxName, '-p', '#{window_width} #{window_height}'],
+        { timeout: 2000, encoding: 'utf8' }
+      ).trim();
+      const [w, h] = sizeStr.split(' ').map(Number);
+      if (w > 0 && h > 0) {
+        ptyCols = w;
+        ptyRows = h;
+      }
+    } catch {
+      /* fall back to 120x40 */
+    }
     try {
       this.ptyProcess = pty.spawn(mux.getAttachCommand(), mux.getAttachArgs(this._muxSession!.muxName), {
         name: 'xterm-256color',
-        cols: 120,
-        rows: 40,
+        cols: ptyCols,
+        rows: ptyRows,
         cwd: this.workingDir,
         env: buildMuxAttachEnv(),
       });

--- a/src/tmux-manager.ts
+++ b/src/tmux-manager.ts
@@ -556,7 +556,7 @@ export class TmuxManager extends EventEmitter implements TerminalMultiplexer {
       // (Production uses systemd which has a clean env, but dev/test may be nested.)
       const cleanEnv = { ...process.env };
       delete cleanEnv.TMUX;
-      execSync(`tmux new-session -ds "${muxName}" -c "${workingDir}" -x 120 -y 40`, {
+      execSync(`tmux new-session -ds "${muxName}" -c "${workingDir}"`, {
         cwd: workingDir,
         timeout: EXEC_TIMEOUT_MS,
         stdio: 'ignore',


### PR DESCRIPTION
## Summary

When a PTY client re-attaches to an existing tmux session, the PTY size is hardcoded to **120x40**, so tmux resizes the window to match the smaller dimensions. The xterm.js client then immediately resizes back to its actual viewport on the next render tick — every restart causes a visible flicker and loses one repaint of scrollback content.

Two small changes fix this:

- **`src/session.ts`** — query the existing tmux window size via `tmux display -t <muxName> -p '#{window_width} #{window_height}'` before `pty.spawn`, fall back to 120x40 only if the call fails.
- **`src/tmux-manager.ts`** — drop the hardcoded `-x 120 -y 40` from `tmux new-session` so the initial size matches the first attaching client.

`execFileSync` is used (not `execSync`) so the muxName isn't shell-interpolated.

## Test plan

- [ ] Start a session, wait for buffer to fill (>40 rows of output).
- [ ] Hard-reload the page (Ctrl+Shift+R).
- [ ] Observe: no flicker, no buffer truncation.
- [ ] Restart with a non-default xterm size (e.g. wide window): on attach the PTY/tmux are sized to match.
- [ ] Kill tmux mid-attach (corner case): falls back to 120x40 gracefully (catch block in the `try { execFileSync … }`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)