### PR TITLE
fix(renderer): WebGL longtask auto-fallback to canvas renderer

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -617,12 +617,55 @@ class CodemanApp {
       this._webglAddon = new WebglAddon.WebglAddon();
       this._webglAddon.onContextLoss(() => {
         console.error('[CRASH-DIAG] WebGL context LOST — falling back to canvas renderer');
-        this._webglAddon.dispose();
+        _crashDiag.log('WEBGL_LOST');
+        this._disableWebGLSticky('context-lost');
+        this._webglAddon?.dispose();
         this._webglAddon = null;
       });
       this.terminal.loadAddon(this._webglAddon);
       console.log('[CRASH-DIAG] WebGL renderer enabled');
+      this._installWebGLLongTaskGuard();
     } catch (_e) { /* WebGL2 unavailable — canvas renderer used */ }
+  }
+
+  /**
+   * Watch for sustained main-thread stalls that indicate WebGL/GPU trouble.
+   * After 3 long tasks (>=200ms each) within 30s, dispose the WebGL addon and
+   * persist a sticky disable so subsequent reloads also use the DOM renderer.
+   * 5s grace period skips initial-load stalls. Force-re-enable: ?webgl=force.
+   */
+  _installWebGLLongTaskGuard() {
+    if (typeof PerformanceObserver === 'undefined' || this._webglLongTaskObserver) return;
+    const installedAt = performance.now();
+    const recent = [];
+    try {
+      this._webglLongTaskObserver = new PerformanceObserver((list) => {
+        if (!this._webglAddon) return;
+        const now = performance.now();
+        if (now - installedAt < 5000) return;
+        for (const entry of list.getEntries()) {
+          if (entry.duration >= 200) recent.push(entry.startTime);
+        }
+        while (recent.length && now - recent[0] > 30000) recent.shift();
+        if (recent.length >= 3) {
+          console.warn(`[CRASH-DIAG] WebGL long-task threshold (${recent.length} stalls/30s) — falling back to canvas renderer`);
+          _crashDiag.log(`WEBGL_FALLBACK: ${recent.length}`);
+          this._disableWebGLSticky('long-tasks');
+          this._webglAddon?.dispose();
+          this._webglAddon = null;
+          try { this._webglLongTaskObserver.disconnect(); } catch {}
+          this._webglLongTaskObserver = null;
+          try { this.terminal.refresh(0, this.terminal.rows - 1); } catch {}
+        }
+      });
+      this._webglLongTaskObserver.observe({ type: 'longtask', buffered: false });
+    } catch { /* longtask not supported */ }
+  }
+
+  _disableWebGLSticky(reason) {
+    try {
+      localStorage.setItem('codeman-webgl-disabled', JSON.stringify({ reason, at: Date.now() }));
+    } catch {}
   }
 
   // ═══════════════════════════════════════════════════════════════

--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -174,10 +174,36 @@ Object.assign(CodemanApp.prototype, {
     // but the 48KB/frame flush cap in flushPendingWrites() now prevents
     // oversized terminal.write() calls that triggered the stalls.
     // Disable with ?nowebgl URL param if GPU issues return.
+    // Auto-fallback: _initWebGL installs a long-task watchdog that disables
+    // WebGL sticky in localStorage after repeated GPU stalls (see app.js).
+    // Force re-enable after sticky disable with ?webgl=force.
     // Lazy-loaded: script downloaded only on desktop (saves 244KB on mobile).
     this._webglAddon = null;
-    const skipWebGL = MobileDetection.getDeviceType() !== 'desktop';
-    if (!skipWebGL && !new URLSearchParams(location.search).has('nowebgl')) {
+    const _params = new URLSearchParams(location.search);
+    if (_params.get('webgl') === 'force') {
+      try { localStorage.removeItem('codeman-webgl-disabled'); } catch {}
+    }
+    const _stickyDisabled = (() => {
+      try {
+        const raw = localStorage.getItem('codeman-webgl-disabled');
+        if (!raw) return false;
+        const { at } = JSON.parse(raw);
+        // Auto-expire after 7 days so we retry (driver may have been fixed)
+        if (Date.now() - at > 7 * 24 * 60 * 60 * 1000) {
+          localStorage.removeItem('codeman-webgl-disabled');
+          return false;
+        }
+        return true;
+      } catch { return false; }
+    })();
+    const skipWebGL =
+      MobileDetection.getDeviceType() !== 'desktop' ||
+      _params.has('nowebgl') ||
+      _stickyDisabled;
+    if (_stickyDisabled) {
+      console.log('[CRASH-DIAG] WebGL sticky-disabled from prior stalls — DOM renderer in use. Re-enable: ?webgl=force');
+    }
+    if (!skipWebGL) {
       if (typeof WebglAddon !== 'undefined') {
         this._initWebGL();
       } else {


### PR DESCRIPTION
## Summary

The xterm WebGL renderer can stall the main thread for hundreds of ms under GPU pressure (driver hiccup, integrated-GPU memory pressure, hardware-accelerated browser layers contending for the GPU). Symptom: the page becomes intermittently unresponsive and Chrome eventually shows the **Page Unresponsive** dialog. Today the only mitigation is `?nowebgl`, which the user has to remember and re-apply on every load.

This patch installs a `PerformanceObserver` after WebGL init that watches for sustained main-thread stalls and falls back to the DOM renderer automatically.

## Behavior

- **Threshold**: 3 long tasks of ≥ 200ms each within a 30s rolling window.
- **5s grace period** after init — skips noisy initial-load stalls so a slow first paint doesn't trip the guard.
- **On trigger**: dispose the WebGL addon, write a sticky disable to `localStorage` (`codeman-webgl-disabled`) with `{ reason, at }`, and `terminal.refresh()` so the canvas renderer takes over without a page reload.
- **Subsequent loads** honor the sticky disable for **7 days**, then auto-expire so users retry after a driver/Chrome update.
- **`?webgl=force`** clears the sticky entry and forces WebGL to re-init.
- **`?nowebgl` unchanged** — still wins as the manual escape hatch.
- The same disable path is reused by the existing `onContextLoss` callback, so a hard context loss also persists across reloads.

## Files

- `src/web/public/app.js` — `_initWebGL` `onContextLoss` now persists + schedules the watchdog; two new helpers: `_installWebGLLongTaskGuard()` and `_disableWebGLSticky(reason)`.
- `src/web/public/terminal-ui.js` — WebGL init reads the sticky entry with 7-day expiry, honors `?webgl=force`, threads sticky into `skipWebGL` alongside the existing mobile + `?nowebgl` gates.

## Browser support

`PerformanceObserver` longtask is supported in Chromium and Edge. The `try/catch` around `.observe({ type: 'longtask' })` makes Firefox/Safari (no longtask entry type) silently no-op — they just keep WebGL with no watchdog.

## Test plan

- [ ] Normal load on Chrome desktop: WebGL initializes, watchdog installs, no false trips after 30s of normal use.
- [ ] Force a long task during typing (e.g. `for (let i=0;i<3;i++) { const t=performance.now(); while(performance.now()-t<250){} await new Promise(r=>setTimeout(r,1000)); }` in DevTools console): after 3 stalls within 30s, the canvas renderer takes over silently and `localStorage.codeman-webgl-disabled` is set.
- [ ] Reload: WebGL stays off, console logs the sticky-disable message.
- [ ] `?webgl=force`: sticky entry cleared, WebGL re-initializes.
- [ ] After 7 days (or manually setting `at` to an old timestamp): sticky entry auto-clears on next load.
- [ ] Firefox/Safari: WebGL stays on (no longtask entry type — guard silently no-ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)