### PR TITLE
fix: drop phantom ended-tab stubs, trust server as source of truth

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -1794,8 +1794,10 @@ class CodemanApp {
       }
     });
 
-    // Restore tabs that were open before refresh but are no longer on the server
-    this._restoreEndedTabs();
+    // Server is source of truth for open sessions — don't resurrect stale tabs
+    // from localStorage (would show phantom "ended" tabs when a session was closed
+    // on another device).
+    try { localStorage.removeItem('codeman-tab-meta'); } catch {}
 
     // Sync sessionOrder with current sessions (preserve order, add new, remove stale)
     this.syncSessionOrder();
@@ -2117,8 +2119,7 @@ class CodemanApp {
       const tallTabsEnabled = this._tallTabsEnabled ?? false;
       const showFolder = tallTabsEnabled && session.name && folderName && folderName !== name;
 
-      const endedAttr = session._ended ? ' data-ended="1"' : '';
-      parts.push(`<div class="session-tab ${isActive ? 'active' : ''}${alertClass}" data-id="${id}" data-color="${color}"${endedAttr} onclick="app.selectSession('${escapeHtml(id)}')" oncontextmenu="event.preventDefault(); app.startInlineRename('${escapeHtml(id)}')" tabindex="0" role="tab" aria-selected="${isActive ? 'true' : 'false'}" aria-label="${escapeHtml(name)} session" ${session.workingDir ? `title="${escapeHtml(session.workingDir)}"` : ''}>
+      parts.push(`<div class="session-tab ${isActive ? 'active' : ''}${alertClass}" data-id="${id}" data-color="${color}" onclick="app.selectSession('${escapeHtml(id)}')" oncontextmenu="event.preventDefault(); app.startInlineRename('${escapeHtml(id)}')" tabindex="0" role="tab" aria-selected="${isActive ? 'true' : 'false'}" aria-label="${escapeHtml(name)} session" ${session.workingDir ? `title="${escapeHtml(session.workingDir)}"` : ''}>
           ${_tabIdx < 9 ? '<span class="tab-number">' + (_tabIdx + 1) + '</span>' : ''}
           <span class="tab-status ${status}" aria-hidden="true"></span>
           <span class="tab-info">
@@ -2137,9 +2138,6 @@ class CodemanApp {
     }
 
     container.innerHTML = parts.join('');
-
-    // Persist tab metadata for refresh recovery
-    this._saveTabMetadata();
 
     // Set up drag-and-drop handlers for tab reordering
     this.setupTabDragHandlers();
@@ -2238,33 +2236,6 @@ class CodemanApp {
     } catch {
       // Ignore storage errors
     }
-  }
-
-  // Save tab metadata to localStorage so ended sessions can be restored after refresh
-  _saveTabMetadata() {
-    try {
-      const meta = {};
-      for (const [id, s] of this.sessions) {
-        if (s._ended) continue; // Don't persist ended stubs back
-        meta[id] = { id, name: s.name || '', workingDir: s.workingDir || '', mode: s.mode || 'claude', color: s.color || 'default' };
-      }
-      localStorage.setItem('codeman-tab-meta', JSON.stringify(meta));
-    } catch { /* ignore */ }
-  }
-
-  // Restore tabs that were open before refresh but are no longer on the server
-  _restoreEndedTabs() {
-    try {
-      const saved = localStorage.getItem('codeman-tab-meta');
-      if (!saved) return;
-      const meta = JSON.parse(saved);
-      for (const [id, info] of Object.entries(meta)) {
-        if (!this.sessions.has(id)) {
-          // Add a stub session so the tab renders
-          this.sessions.set(id, { id, name: info.name, workingDir: info.workingDir, mode: info.mode, color: info.color, status: 'ended', _ended: true });
-        }
-      }
-    } catch { /* ignore */ }
   }
 
   // Set up drag-and-drop handlers on tab elements
@@ -2546,16 +2517,9 @@ class CodemanApp {
     // Check if this is a restored session that needs to be attached
     const session = this.sessions.get(sessionId);
 
-    // Ended tabs (restored from localStorage, no longer on server) — show message, skip buffer load
-    if (session?._ended) {
-      this.terminal.clear();
-      this.terminal.write('\r\n  \x1b[2mSession ended. Close tab or click to reopen.\x1b[0m\r\n');
-      return;
-    }
-
     // Track working directory for path normalization in Project Insights
     this.currentSessionWorkingDir = session?.workingDir || null;
-    if (session && session.pid === null && !session._ended) {
+    if (session && session.pid === null) {
       // Session has no PTY attached — either restored after server restart
       // or detached for some other reason. Re-attach regardless of status.
       try {

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -293,7 +293,6 @@ body {
 }
 .session-tab .tab-status.error { background: var(--red); }
 .session-tab .tab-status.ended { background: var(--text-muted); opacity: 0.5; }
-.session-tab[data-ended] { opacity: 0.55; }
 
 /* Session color coding - left border indicator */
 .session-tab[data-color="red"] { border-left: 3px solid var(--session-red); }

--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -444,7 +444,6 @@ Object.assign(CodemanApp.prototype, {
             if (
               activeResizeSession &&
               activeResizeSession.mode !== 'shell' &&
-              !activeResizeSession._ended &&
               this.terminal &&
               this.isTerminalAtBottom()
             ) {


### PR DESCRIPTION
## Summary

The client cached open session tabs in `localStorage` and resurrected any that the server no longer knew about as grayed-out "ended" stubs. On **multi-device use** (close tab on mobile, open desktop) this left stale phantom tabs the user had to manually dismiss every time.

## Fix

Drop the client-side resurrection path entirely; let the server be the source of truth for which sessions are open.

Removed:
- `_restoreEndedTabs` / `_saveTabMetadata`
- The `session._ended` branch in `selectSession`
- The `data-ended` render attribute and its matching CSS rule

Also clears the legacy `localStorage` key on init to purge stale entries left by previous client versions.

Net: **-44 / +6 lines** — removes complexity while fixing the UX bug.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] Manual verification: close a tab on mobile, refresh desktop — no phantom grayed-out tab appears.
- [x] Manual verification: existing legacy `localStorage` entries from older clients are cleared on next page load.