### PR TITLE
feat(settings): label Gesture Control as (beta)

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -983,7 +983,7 @@
               <div id="appSettingsInputSection">
                 <div class="settings-section-header">Input</div>
                 <div class="settings-item" title="Enable the camera hand-tracking gesture overlay (applied on reload). The instance must run with CODEMAN_GESTURE=1.">
-                  <span class="settings-item-label">Gesture Control</span>
+                  <span class="settings-item-label">Gesture Control (beta)</span>
                   <label class="switch switch-sm">
                     <input type="checkbox" id="appSettingsGestureControl">
                     <span class="slider"></span>


### PR DESCRIPTION
## What
Labels the **Gesture Control** toggle as **(beta)** in App Settings → Input.

## Why
The gesture overlay is an opt-in, experimental feature (camera hand-tracking, requires `CODEMAN_GESTURE=1`); the label should signal that.

## Change
`src/web/public/index.html` — `Gesture Control` → `Gesture Control (beta)` (plain text, no new CSS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)