### PR TITLE
fix(cjk): hide CJK textarea on welcome screen and fix vertical centering

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -2103,7 +2103,13 @@ class CodemanApp {
     // Mobile defaults ship cjkInputEnabled: false (native terminal input by
     // default on touch), but an explicit user enable is honored everywhere —
     // the App Settings toggle must not be a silent no-op on phones.
-    const showCjk = this._serverCjkOverride || (settings.cjkInputEnabled ?? defaults.cjkInputEnabled ?? false);
+    // The welcome/home screen (no active session) has nothing to type into.
+    // Force-hide the CJK textarea there — otherwise the `position: fixed`
+    // `.cjk-input-visible` rule floats it over the welcome overlay and blocks
+    // content. Re-synced on session enter/leave via hideWelcome()/showWelcome().
+    const cjkUserEnabled =
+      this._serverCjkOverride || (settings.cjkInputEnabled ?? defaults.cjkInputEnabled ?? false);
+    const showCjk = cjkUserEnabled && !!this.activeSessionId;
     cjkEl.classList.toggle('cjk-input-visible', !!showCjk);
     document.body.classList.toggle('cjk-input-visible', !!showCjk);
     cjkEl.style.display = showCjk ? 'block' : 'none';

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -8778,6 +8778,7 @@ kbd {
   display: block;
   min-height: 44px;
   max-height: 96px;
+  padding: 12px 10px;
   border: 1px solid rgba(80, 120, 190, 0.55);
   border-left: none;
   border-right: none;

--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -943,6 +943,9 @@ Object.assign(CodemanApp.prototype, {
       this.loadTunnelStatus();
       this.loadHistorySessions();
     }
+    // Home screen has no input target — hide the CJK textarea (activeSessionId
+    // is null by the time we get here). Guarded: defined on the app object.
+    this._updateCjkInputState?.();
   },
 
   hideWelcome() {
@@ -956,6 +959,9 @@ Object.assign(CodemanApp.prototype, {
       clearTimeout(this._welcomeQrShrinkTimer);
       qrWrap.classList.remove('expanded');
     }
+    // Entering a session — restore CJK textarea if the user has it enabled
+    // (activeSessionId is already set by selectSession before this call).
+    this._updateCjkInputState?.();
   },
 
   /**

--- a/test/mobile/keyboard.test.ts
+++ b/test/mobile/keyboard.test.ts
@@ -528,15 +528,24 @@ describe('Virtual Keyboard', () => {
       expect(afterEnter.sentInputs).toEqual(['hello', '\r']);
     });
 
-    it('shows the CJK textarea on mobile only for server override', async () => {
+    it('shows the CJK textarea on mobile for server override only inside an active session', async () => {
       const state = await page.evaluate(() => {
-        app._serverCjkOverride = true;
-        app._updateCjkInputState();
-
         const input = document.getElementById('cjkInput');
         if (!(input instanceof HTMLElement)) return null;
+
+        // Welcome screen (no active session): even with the server override on, the
+        // fixed-position textarea must stay hidden so it doesn't float over the overlay.
+        app.activeSessionId = null;
+        app._serverCjkOverride = true;
+        app._updateCjkInputState();
+        const onWelcomeDisplay = getComputedStyle(input).display;
+
+        // Entering a session reveals it.
+        app.activeSessionId = 'cjk-server-override-test';
+        app._updateCjkInputState();
         const cs = getComputedStyle(input);
         return {
+          onWelcomeDisplay,
           display: cs.display,
           position: cs.position,
           bottom: cs.bottom,
@@ -546,6 +555,7 @@ describe('Virtual Keyboard', () => {
       });
 
       expect(state).not.toBeNull();
+      expect(state?.onWelcomeDisplay).toBe('none');
       expect(state?.display).not.toBe('none');
       expect(state?.position).toBe('fixed');
       expect(Number(state?.zIndex)).toBeGreaterThan(50);


### PR DESCRIPTION
## Summary
- Hide the CJK input textarea on the welcome/home screen (no active session) — the `position: fixed` element was floating over the welcome overlay and blocking content
- Sync CJK textarea visibility on session enter/leave via `showWelcome()`/`hideWelcome()`
- Add vertical padding to the CJK textarea for proper text centering

## Test plan
- [ ] Enable CJK input in settings → navigate to welcome screen → textarea should be hidden
- [ ] Enter a session → CJK textarea appears
- [ ] Switch back to welcome → CJK textarea hides again
- [ ] Verify text is vertically centered in the CJK textarea