### PR TITLE
feat(settings): add Opus 4.6 model options

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -1166,6 +1166,8 @@
                 <option value="claude-fable-5">Fable 5</option>
                 <option value="opus[1m]">Opus (1M context)</option>
                 <option value="opus">Opus</option>
+                <option value="claude-opus-4-6[1m]">Opus 4.6 (1M context)</option>
+                <option value="claude-opus-4-6">Opus 4.6</option>
                 <option value="sonnet">Sonnet</option>
                 <option value="haiku">Haiku</option>
               </select>


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-6[1m]` (1M context) and `claude-opus-4-6` to the Claude Model picker dropdown

## Test plan
- [ ] Open App Settings → Claude Model dropdown shows the two new Opus 4.6 entries
- [ ] Select Opus 4.6 (1M context) → creates session with correct model