### PR TITLE
Make Option/Alt session shortcuts work on macOS (physical key codes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,8 @@ Single-digit selection (1-9), color-coded status, token counts, auto-refresh. De
 |----------|--------|
 | `Ctrl/Cmd+W` | Kill active session |
 | `Ctrl/Cmd+Tab` | Next session |
-| `Alt+1`–`Alt+9` | Switch to tab N |
+| `Option+[` / `Option+]` | Previous / next session |
+| `Option+1`-`Option+9` | Switch to tab N (physical keys, so macOS Option layouts work) |
 | `Ctrl+Shift+{` / `Ctrl+Shift+}` | Move active tab left / right |
 | `Ctrl/Cmd+L` | Clear terminal |
 | `Ctrl+Shift+R` | Restore terminal size |

--- a/README.md
+++ b/README.md
@@ -483,8 +483,8 @@ Single-digit selection (1-9), color-coded status, token counts, auto-refresh. De
 |----------|--------|
 | `Ctrl/Cmd+W` | Kill active session |
 | `Ctrl/Cmd+Tab` | Next session |
-| `Option+[` / `Option+]` | Previous / next session |
-| `Option+1`-`Option+9` | Switch to tab N (physical keys, so macOS Option layouts work) |
+| `Alt/Option+[` / `Alt/Option+]` | Previous / next session |
+| `Alt/Option+1`-`Alt/Option+9` | Switch to tab N (physical keys, so macOS Option layouts work) |
 | `Ctrl+Shift+{` / `Ctrl+Shift+}` | Move active tab left / right |
 | `Ctrl/Cmd+L` | Clear terminal |
 | `Ctrl+Shift+R` | Restore terminal size |

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -770,14 +770,31 @@ class CodemanApp {
         if (this.attachmentHistoryDrawerOpen) this.closeAttachmentHistory();
       }
 
-      // Alt+1-9: switch to Codeman session by index
-      if (e.altKey && !e.ctrlKey && !e.shiftKey && e.key >= '1' && e.key <= '9') {
-        const idx = parseInt(e.key) - 1;
-        if (idx < this.sessionOrder.length) {
-          e.preventDefault();
-          this.selectSession(this.sessionOrder[idx]);
+      // Option/Alt session navigation uses physical key CODES, not e.key, so macOS
+      // keyboard layouts that emit special characters under Option (Option+1 -> ¡,
+      // Option+[ -> "“") still switch sessions. e.code is the physical key regardless
+      // of layout. Option+1-9 = switch by index; Option+[ / Option+] = prev / next.
+      if (e.altKey && !e.ctrlKey && !e.shiftKey) {
+        const code = e.code || '';
+        const digitMatch = code.match(/^Digit([1-9])$/);
+        if (digitMatch) {
+          const idx = parseInt(digitMatch[1], 10) - 1;
+          if (idx < this.sessionOrder.length) {
+            e.preventDefault();
+            this.selectSession(this.sessionOrder[idx]);
+          }
+          return;
         }
-        return;
+        if (e.code === 'BracketLeft') {
+          e.preventDefault();
+          this.prevSession();
+          return;
+        }
+        if (e.code === 'BracketRight') {
+          e.preventDefault();
+          this.nextSession();
+          return;
+        }
       }
 
       // Match against shortcut table

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -505,7 +505,8 @@
           <div class="shortcuts-grid">
             <div><kbd>Ctrl</kbd>+<kbd>W</kbd></div><div>Close Session</div>
             <div><kbd>Ctrl</kbd>+<kbd>Tab</kbd></div><div>Next Session</div>
-            <div><kbd>Alt</kbd>+<kbd>1-9</kbd></div><div>Switch to Tab N</div>
+            <div><kbd>Option</kbd>+<kbd>[</kbd> / <kbd>Option</kbd>+<kbd>]</kbd></div><div>Previous / Next Session</div>
+            <div><kbd>Option</kbd>+<kbd>1-9</kbd></div><div>Switch to Tab N</div>
             <div><kbd>Ctrl</kbd>+<kbd>L</kbd></div><div>Clear Terminal</div>
             <div><kbd>Ctrl</kbd>+<kbd>+</kbd></div><div>Increase Font</div>
             <div><kbd>Ctrl</kbd>+<kbd>-</kbd></div><div>Decrease Font</div>

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -505,8 +505,8 @@
           <div class="shortcuts-grid">
             <div><kbd>Ctrl</kbd>+<kbd>W</kbd></div><div>Close Session</div>
             <div><kbd>Ctrl</kbd>+<kbd>Tab</kbd></div><div>Next Session</div>
-            <div><kbd>Option</kbd>+<kbd>[</kbd> / <kbd>Option</kbd>+<kbd>]</kbd></div><div>Previous / Next Session</div>
-            <div><kbd>Option</kbd>+<kbd>1-9</kbd></div><div>Switch to Tab N</div>
+            <div><kbd>Alt/Option</kbd>+<kbd>[</kbd> / <kbd>Alt/Option</kbd>+<kbd>]</kbd></div><div>Previous / Next Session</div>
+            <div><kbd>Alt/Option</kbd>+<kbd>1-9</kbd></div><div>Switch to Tab N</div>
             <div><kbd>Ctrl</kbd>+<kbd>L</kbd></div><div>Clear Terminal</div>
             <div><kbd>Ctrl</kbd>+<kbd>+</kbd></div><div>Increase Font</div>
             <div><kbd>Ctrl</kbd>+<kbd>-</kbd></div><div>Decrease Font</div>

--- a/src/web/public/terminal-ui.js
+++ b/src/web/public/terminal-ui.js
@@ -114,8 +114,14 @@ Object.assign(CodemanApp.prototype, {
     this.terminal.attachCustomKeyEventHandler((ev) => {
       if (ev.isComposing || ev.keyCode === 229) return false;
 
-      // Let Alt+digit pass through to browser (tab switching)
-      if (ev.altKey && ev.key >= '0' && ev.key <= '9') return false;
+      // Let the app's Alt/Option session-nav shortcuts reach the document keydown handler
+      // (app.js switches tabs by PHYSICAL e.code) instead of xterm injecting ESC<char> into
+      // the PTY. Mirror app.js's gate exactly — same physical codes + modifier guard — so
+      // macOS Option layouts (Option+1 -> "¡", Option+[ -> "“") are suppressed here too and
+      // don't leak an escape sequence into the focused terminal on every tab switch.
+      if (ev.altKey && !ev.ctrlKey && !ev.shiftKey && /^(Digit[1-9]|BracketLeft|BracketRight)$/.test(ev.code || '')) {
+        return false;
+      }
 
       // Ctrl+V / Cmd+V: intercept before xterm sends ^V to PTY.
       // Route through our paste trap which handles both images and text.

--- a/test/keyboard-shortcuts.test.ts
+++ b/test/keyboard-shortcuts.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const appSource = readFileSync('src/web/public/app.js', 'utf8');
+const helpHtml = readFileSync('src/web/public/index.html', 'utf8');
+const readme = readFileSync('README.md', 'utf8');
+
+describe('keyboard shortcuts', () => {
+  it('uses physical Option+number keys so macOS special characters do not break tab switching', () => {
+    expect(appSource).toContain('e.code ||');
+    expect(appSource).toContain('Digit([1-9])');
+    expect(appSource).toContain('parseInt(digitMatch[1], 10) - 1');
+  });
+
+  it('provides Option+bracket shortcuts for previous and next session', () => {
+    expect(appSource).toContain("e.code === 'BracketLeft'");
+    expect(appSource).toContain("e.code === 'BracketRight'");
+    expect(appSource).toContain('this.prevSession()');
+    expect(appSource).toContain('this.nextSession()');
+  });
+
+  it('documents mac-friendly Option shortcuts in help and README', () => {
+    expect(helpHtml).toContain('<kbd>Option</kbd>+<kbd>[</kbd>');
+    expect(helpHtml).toContain('<kbd>Option</kbd>+<kbd>]</kbd>');
+    expect(helpHtml).toContain('<kbd>Option</kbd>+<kbd>1-9</kbd>');
+    expect(readme).toContain('`Option+[` / `Option+]`');
+    expect(readme).toContain('`Option+1`-`Option+9`');
+  });
+});

--- a/test/keyboard-shortcuts.test.ts
+++ b/test/keyboard-shortcuts.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const appSource = readFileSync('src/web/public/app.js', 'utf8');
+const terminalUiSource = readFileSync('src/web/public/terminal-ui.js', 'utf8');
 const helpHtml = readFileSync('src/web/public/index.html', 'utf8');
 const readme = readFileSync('README.md', 'utf8');
 
@@ -19,11 +20,18 @@ describe('keyboard shortcuts', () => {
     expect(appSource).toContain('this.nextSession()');
   });
 
-  it('documents mac-friendly Option shortcuts in help and README', () => {
-    expect(helpHtml).toContain('<kbd>Option</kbd>+<kbd>[</kbd>');
-    expect(helpHtml).toContain('<kbd>Option</kbd>+<kbd>]</kbd>');
-    expect(helpHtml).toContain('<kbd>Option</kbd>+<kbd>1-9</kbd>');
-    expect(readme).toContain('`Option+[` / `Option+]`');
-    expect(readme).toContain('`Option+1`-`Option+9`');
+  it('suppresses xterm PTY injection for the same physical Alt nav codes (no ESC leak)', () => {
+    // terminal-ui.js must gate its xterm pass-through on the SAME physical e.code set the
+    // app.js handler consumes; otherwise Alt+[ / Alt+] (and Option+digit on remapped macOS
+    // layouts) switch tabs AND inject ESC<char> into the focused terminal. Keep in sync.
+    expect(terminalUiSource).toContain('/^(Digit[1-9]|BracketLeft|BracketRight)$/.test(ev.code');
+  });
+
+  it('documents the Alt/Option shortcuts in help and README', () => {
+    expect(helpHtml).toContain('<kbd>Alt/Option</kbd>+<kbd>[</kbd>');
+    expect(helpHtml).toContain('<kbd>Alt/Option</kbd>+<kbd>]</kbd>');
+    expect(helpHtml).toContain('<kbd>Alt/Option</kbd>+<kbd>1-9</kbd>');
+    expect(readme).toContain('`Alt/Option+[` / `Alt/Option+]`');
+    expect(readme).toContain('`Alt/Option+1`-`Alt/Option+9`');
   });
 });


### PR DESCRIPTION
## Problem

The tab-switch shortcuts matched `e.key`, e.g. `e.altKey && e.key >= '1' && e.key <= '9'`. On macOS, **Option+1** emits the special character `¡` (not `1`), so `e.key` is `'¡'` and the shortcut silently does nothing. Same story for any layout where Option/Alt is a dead/compose key.

## Fix

Match the **physical key code** (`e.code`) instead of the produced character, which is layout-independent:

- `Option/Alt + 1–9` → switch to tab N, via `e.code === 'Digit1'…'Digit9'`.
- Adds `Option/Alt + [` → previous session and `Option/Alt + ]` → next session (`BracketLeft`/`BracketRight` → `prevSession()`/`nextSession()`).

Help modal (`index.html`) and the README shortcut table are updated to show the Option bindings.

## Tests / verification

- `test/keyboard-shortcuts.test.ts` asserts the physical-code handling + the help/README docs.
- `tsc --noEmit`, `check:frontend-syntax`, `check:public-assets`, `build` clean.
- Real-browser check: synthetic `keydown` with `altKey` + `code` routes Option+2 → `selectSession`, Option+[ → `prevSession`, Option+] → `nextSession`; 0 console errors.