### PR TITLE
Harden ultracode inline onclick handlers against XSS

### DIFF
--- a/src/web/public/ultracode-panel.js
+++ b/src/web/public/ultracode-panel.js
@@ -204,7 +204,7 @@ Object.assign(CodemanApp.prototype, {
       phasesHtml = `<div class="ultracode-phase-list">${chips.join('')}</div>`;
     }
     return (
-      `<div class="ultracode-run-item${active ? ' selected' : ''}" onclick="app.selectWorkflowRun('${escapeHtml(r.runId)}')">` +
+      `<div class="ultracode-run-item${active ? ' selected' : ''}" onclick="app.selectWorkflowRun(${escapeHtml(JSON.stringify(r.runId))})">` +
       `<div class="ultracode-run-head"><span class="ultracode-run-name">${name}</span>` +
       `<span class="ultracode-status ${statusCls}">${escapeHtml(status || '—')}</span></div>` +
       `<div class="ultracode-run-stats">${escapeHtml(stats)}</div>` +
@@ -279,7 +279,7 @@ Object.assign(CodemanApp.prototype, {
     const cardStateCls = state === 'done' ? ' uw-state-done' : state === 'progress' ? ' uw-state-working' : '';
     const cardAttrs = clickable
       ? ` class="ultracode-agent-card ultracode-agent-card--clickable${cardStateCls}" role="button" tabindex="0"` +
-        ` title="View transcript" onclick="app.openUltracodeAgentWindow('${escapeHtml(a.agentId)}','${escapeHtml(runId || '')}')"`
+        ` title="View transcript" onclick="app.openUltracodeAgentWindow(${escapeHtml(JSON.stringify(a.agentId))},${escapeHtml(JSON.stringify(runId || ''))})"`
       : ` class="ultracode-agent-card${cardStateCls}"`;
     return (
       `<div${cardAttrs}>` +

--- a/src/web/public/ultracode-windows.js
+++ b/src/web/public/ultracode-windows.js
@@ -351,11 +351,11 @@ Object.assign(CodemanApp.prototype, {
         const name = run ? run.workflowName || run.summary || runId : runId;
         const statusCls = this._workflowStatusClass(run ? String(run.status || '') : '');
         items.push(
-          `<div class="subagent-dropdown-item" onclick="event.stopPropagation(); app.restoreUltracodeRunFromTab('${escapeHtml(runId)}','${escapeHtml(sessionId)}')" title="Click to restore run">` +
+          `<div class="subagent-dropdown-item" onclick="event.stopPropagation(); app.restoreUltracodeRunFromTab(${escapeHtml(JSON.stringify(runId))},${escapeHtml(JSON.stringify(sessionId))})" title="Click to restore run">` +
             `<span class="subagent-dropdown-status ${statusCls}"></span>` +
             `<span class="ultracode-dd-icon">🧬</span>` +
             `<span class="subagent-dropdown-name">${escapeHtml(trunc(name))}</span>` +
-            `<span class="subagent-dropdown-close" onclick="event.stopPropagation(); app.dismissMinimizedUltracodeRun('${escapeHtml(runId)}','${escapeHtml(sessionId)}')" title="Dismiss">&times;</span>` +
+            `<span class="subagent-dropdown-close" onclick="event.stopPropagation(); app.dismissMinimizedUltracodeRun(${escapeHtml(JSON.stringify(runId))},${escapeHtml(JSON.stringify(sessionId))})" title="Dismiss">&times;</span>` +
             `</div>`
         );
       }
@@ -365,11 +365,11 @@ Object.assign(CodemanApp.prototype, {
       for (const [agentId, entry] of agentMap) {
         const name = (entry && entry.label) || agentId;
         items.push(
-          `<div class="subagent-dropdown-item" onclick="event.stopPropagation(); app.restoreUltracodeAgentFromTab('${escapeHtml(agentId)}','${escapeHtml(sessionId)}')" title="Click to restore transcript">` +
+          `<div class="subagent-dropdown-item" onclick="event.stopPropagation(); app.restoreUltracodeAgentFromTab(${escapeHtml(JSON.stringify(agentId))},${escapeHtml(JSON.stringify(sessionId))})" title="Click to restore transcript">` +
             `<span class="subagent-dropdown-status"></span>` +
             `<span class="ultracode-dd-icon">📄</span>` +
             `<span class="subagent-dropdown-name">${escapeHtml(trunc(name))}</span>` +
-            `<span class="subagent-dropdown-close" onclick="event.stopPropagation(); app.dismissMinimizedUltracodeAgent('${escapeHtml(agentId)}','${escapeHtml(sessionId)}')" title="Dismiss">&times;</span>` +
+            `<span class="subagent-dropdown-close" onclick="event.stopPropagation(); app.dismissMinimizedUltracodeAgent(${escapeHtml(JSON.stringify(agentId))},${escapeHtml(JSON.stringify(sessionId))})" title="Dismiss">&times;</span>` +
             `</div>`
         );
       }


### PR DESCRIPTION
## Summary

The ultracode run/agent cards and minimized-tab badges build inline `onclick` handlers by interpolating `escapeHtml(value)` inside **single-quoted JavaScript strings within an HTML attribute**, e.g.:

```js
onclick="app.openUltracodeAgentWindow('${escapeHtml(a.agentId)}','${escapeHtml(runId || '')}')"
```

`escapeHtml` maps `'` → `&#39;`, but the browser **HTML-decodes the attribute value before the handler source is parsed**, so `&#39;` becomes a literal `'` again and a quote in a run/agent/session id breaks out of the string literal into executable JS. `escapeHtml` alone is insufficient for the JS-string-within-HTML-attribute double context.

## Fix

Switch each handler to `escapeHtml(JSON.stringify(value))`: `JSON.stringify` JS-encodes and quote-wraps the value first, then `escapeHtml` handles the HTML-attribute layer, so the value round-trips as an inert string argument. This matches the encoding convention already used by other handlers in these files.

Affected handlers (6):
- `ultracode-panel.js` — `selectWorkflowRun`, `openUltracodeAgentWindow`
- `ultracode-windows.js` — `restoreUltracodeRunFromTab`, `dismissMinimizedUltracodeRun`, `restoreUltracodeAgentFromTab`, `dismissMinimizedUltracodeAgent`

## Verification

- No single-quoted `escapeHtml` inline handler remains.
- `node --check` parses both files cleanly.
- Runtime repro under HTML-attribute decoding: a quote-bearing id (`');window.__PWNED=1;('`) parses as a **separate executable statement** under the old pattern, but round-trips as a single inert string argument under the fix — nothing executes.