### PR TITLE
Add Ralph todo-config (maxTodos / todoExpirationMinutes)

### DIFF
--- a/src/ralph-tracker.ts
+++ b/src/ralph-tracker.ts
@@ -467,6 +467,12 @@ export class RalphTracker extends EventEmitter {
   /** Timestamp of last cleanup check for throttling */
   private _lastCleanupTime: number = 0;
 
+  /** Maximum number of todos retained for this session (defaults to global cap) */
+  private _maxTodos: number = MAX_TODOS_PER_SESSION;
+
+  /** Todo auto-expiry duration in milliseconds (defaults to global constant) */
+  private _todoExpiryMs: number = TODO_EXPIRY_MS;
+
   /** Debouncer for todoUpdate events */
   private _todoDeb = new Debouncer(EVENT_DEBOUNCE_MS);
 
@@ -1840,7 +1846,7 @@ export class RalphTracker extends EventEmitter {
         return;
       }
 
-      while (this._todos.size >= MAX_TODOS_PER_SESSION) {
+      while (this._todos.size >= this._maxTodos) {
         const oldest = this.findOldestTodo();
         if (oldest) {
           this._todos.delete(oldest.id);
@@ -2164,14 +2170,14 @@ export class RalphTracker extends EventEmitter {
   }
 
   /**
-   * Remove todo items older than TODO_EXPIRY_MS.
+   * Remove todo items older than the configured expiry duration.
    */
   private cleanupExpiredTodos(): void {
     const now = Date.now();
     const toDelete: string[] = [];
 
     for (const [id, todo] of this._todos) {
-      if (now - todo.detectedAt > TODO_EXPIRY_MS) {
+      if (now - todo.detectedAt > this._todoExpiryMs) {
         toDelete.push(id);
       }
     }
@@ -2209,6 +2215,34 @@ export class RalphTracker extends EventEmitter {
     this._loopState.maxIterations = maxIterations;
     this._loopState.lastActivity = Date.now();
     this.emit('loopUpdate', this.loopState);
+  }
+
+  /** Maximum number of todos retained for this session. */
+  get maxTodos(): number {
+    return this._maxTodos;
+  }
+
+  /** Todo auto-expiry duration in minutes for this session. */
+  get todoExpirationMinutes(): number {
+    return Math.round(this._todoExpiryMs / 60000);
+  }
+
+  /**
+   * Update the maximum number of retained todos (external API).
+   * Ignores non-positive values.
+   */
+  setMaxTodos(maxTodos: number): void {
+    if (!Number.isFinite(maxTodos) || maxTodos <= 0) return;
+    this._maxTodos = Math.floor(maxTodos);
+  }
+
+  /**
+   * Update the todo auto-expiry duration (external API), specified in minutes.
+   * Converts to milliseconds internally. Ignores non-positive values.
+   */
+  setTodoExpirationMinutes(minutes: number): void {
+    if (!Number.isFinite(minutes) || minutes <= 0) return;
+    this._todoExpiryMs = Math.floor(minutes) * 60000;
   }
 
   /**

--- a/src/web/routes/ralph-routes.ts
+++ b/src/web/routes/ralph-routes.ts
@@ -32,17 +32,16 @@ export function registerRalphRoutes(
   // Configure Ralph tracker for a session
   app.post('/api/sessions/:id/ralph-config', async (req) => {
     const { id } = req.params as { id: string };
-    const { enabled, completionPhrase, maxIterations, reset, disableAutoEnable } = parseBody(
-      RalphConfigSchema,
-      req.body,
-      'Invalid request body'
-    ) as {
-      enabled?: boolean;
-      completionPhrase?: string;
-      maxIterations?: number;
-      reset?: boolean | 'full';
-      disableAutoEnable?: boolean;
-    };
+    const { enabled, completionPhrase, maxIterations, maxTodos, todoExpirationMinutes, reset, disableAutoEnable } =
+      parseBody(RalphConfigSchema, req.body, 'Invalid request body') as {
+        enabled?: boolean;
+        completionPhrase?: string;
+        maxIterations?: number;
+        maxTodos?: number;
+        todoExpirationMinutes?: number;
+        reset?: boolean | 'full';
+        disableAutoEnable?: boolean;
+      };
     const session = findSessionOrFail(ctx, id);
 
     // Ralph tracker is not supported for external-CLI sessions (opencode/codex)
@@ -96,6 +95,14 @@ export function registerRalphRoutes(
 
     if (maxIterations !== undefined) {
       session.ralphTracker.setMaxIterations(maxIterations || null);
+    }
+
+    if (maxTodos !== undefined) {
+      session.ralphTracker.setMaxTodos(maxTodos);
+    }
+
+    if (todoExpirationMinutes !== undefined) {
+      session.ralphTracker.setTodoExpirationMinutes(todoExpirationMinutes);
     }
 
     // Persist and broadcast the update

--- a/src/web/schemas.ts
+++ b/src/web/schemas.ts
@@ -497,6 +497,8 @@ export const RalphConfigSchema = z.object({
   enabled: z.boolean().optional(),
   completionPhrase: z.string().max(500).optional(),
   maxIterations: z.number().int().min(0).max(10000).optional(),
+  maxTodos: z.number().int().positive().max(10000).optional(),
+  todoExpirationMinutes: z.number().int().positive().max(525600).optional(),
   reset: z.union([z.boolean(), z.literal('full')]).optional(),
   disableAutoEnable: z.boolean().optional(),
 });

--- a/test/routes/ralph-routes.test.ts
+++ b/test/routes/ralph-routes.test.ts
@@ -21,6 +21,8 @@ function createMockRalphTracker() {
     disableAutoEnable: vi.fn(),
     startLoop: vi.fn(),
     setMaxIterations: vi.fn(),
+    setMaxTodos: vi.fn(),
+    setTodoExpirationMinutes: vi.fn(),
     resetCircuitBreaker: vi.fn(),
     generateFixPlanMarkdown: vi.fn(() => '# Fix Plan\n\n- [ ] Task 1\n'),
     importFixPlanMarkdown: vi.fn(() => 3),
@@ -156,6 +158,25 @@ describe('ralph-routes', () => {
         payload: { maxIterations: 50 },
       });
       expect(tracker.setMaxIterations).toHaveBeenCalledWith(50);
+    });
+
+    it('applies maxTodos and todoExpirationMinutes to the tracker (COD-52)', async () => {
+      const tracker = (harness.ctx._session as Record<string, unknown>).ralphTracker as ReturnType<
+        typeof createMockRalphTracker
+      >;
+
+      const res = await harness.app.inject({
+        method: 'POST',
+        url: `/api/sessions/${harness.ctx._sessionId}/ralph-config`,
+        payload: { maxTodos: 25, todoExpirationMinutes: 90 },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      // The ralph-config success path returns a bare {} envelope (matching its
+      // sibling config routes); an error would surface as { success: false }.
+      expect(body.success).not.toBe(false);
+      expect(tracker.setMaxTodos).toHaveBeenCalledWith(25);
+      expect(tracker.setTodoExpirationMinutes).toHaveBeenCalledWith(90);
     });
 
     it('returns error for unknown session', async () => {


### PR DESCRIPTION
## Summary

Makes the Ralph autonomous loop's todo handling configurable through the existing ralph-config route, rather than using hardcoded values.

- Adds `maxTodos` and `todoExpirationMinutes` to the ralph-config schema.
- Wires both values through the ralph-config route to the tracker via `setMaxTodos()` / `setTodoExpirationMinutes()`.

## Files

`src/ralph-tracker.ts`, `src/web/routes/ralph-routes.ts`, `src/web/schemas.ts`, `test/routes/ralph-routes.test.ts`.

## Testing

- `tsc --noEmit`: clean
- `test/routes/ralph-routes.test.ts`: 34/34
- `npm run build`: passes
