### PR TITLE
fix(mobile): improve response-viewer readability on phones

### DIFF
--- a/src/web/public/mobile.css
+++ b/src/web/public/mobile.css
@@ -1259,7 +1259,10 @@ html.mobile-init .file-browser-panel {
 
   .response-viewer {
     padding-bottom: var(--safe-area-bottom, 0px);
-    max-height: 92vh;
+    /* dvh tracks the visible viewport on iOS Safari (vh = large viewport and would clip
+       the header/close button off-screen); the vh line is the old-engine fallback */
+    max-height: 88vh;
+    max-height: 92dvh;
   }
 
   .response-viewer-body {

--- a/src/web/public/mobile.css
+++ b/src/web/public/mobile.css
@@ -1259,12 +1259,37 @@ html.mobile-init .file-browser-panel {
 
   .response-viewer {
     padding-bottom: var(--safe-area-bottom, 0px);
+    max-height: 92vh;
   }
 
   .response-viewer-body {
-    font-size: 12px;
-    padding: 12px;
+    font-size: 14.5px;
+    line-height: 1.65;
+    padding: 16px 16px 24px;
+    --rv-content-max: 100%;
   }
+
+  .response-viewer-body .rv-text pre,
+  .response-viewer-body pre {
+    /* Slightly smaller on mobile so diagrams fit better before scrolling */
+    padding: 12px 14px;
+    margin-left: -4px;
+    margin-right: -4px;
+    border-radius: 6px;
+  }
+
+  .response-viewer-body .rv-text pre code,
+  .response-viewer-body pre code {
+    font-size: 11.5px;
+    line-height: 1.5;
+  }
+
+  .response-viewer-body .rv-text h1,
+  .response-viewer-body > h1 { font-size: 1.35em; }
+  .response-viewer-body .rv-text h2,
+  .response-viewer-body > h2 { font-size: 1.2em; }
+  .response-viewer-body .rv-text h3,
+  .response-viewer-body > h3 { font-size: 1.08em; }
 
   /* Compact welcome overlay for mobile */
   .welcome-content {


### PR DESCRIPTION
## Summary

The mobile media query only overrode `.response-viewer-body` with a flat `font-size: 12px` / `padding: 12px`, leaving the desktop response-viewer typography system (`--rv-content-max`, `.rv-text pre`, heading scale defined in `styles.css`) with no mobile tuning. On phones the transcript read cramped and code/diagrams were unnecessarily tiny.

This tunes the existing response-viewer selectors for small screens:
- Body text 12px → **14.5px / line-height 1.65** for comfortable reading
- Code blocks get phone-sized padding + slight negative side-margin, **11.5px** code
- Heading scale (h1 1.35em / h2 1.2em / h3 1.08em)
- Content spans full width on mobile (`--rv-content-max: 100%`)
- Cap the panel at `92vh`

Layers cleanly on top of the existing response-viewer selectors in `styles.css` — **desktop rendering is unchanged**; all changes are scoped inside the mobile media query.

## Test plan
- [ ] Open the response viewer on a phone-width viewport; confirm body text, code blocks, and headings render at the new sizes
- [ ] Confirm ASCII/box diagrams still scroll correctly inside `pre.rv-diagram`
- [ ] Confirm desktop response viewer is visually unchanged