### PR TITLE
fix(auth): slide the session cookie so active users aren't logged out

### DIFF
--- a/.changeset/sliding-auth-cookie.md
+++ b/.changeset/sliding-auth-cookie.md
@@ -1,0 +1,13 @@
+---
+"aicodeman": patch
+---
+
+fix(auth): slide the session cookie so active users aren't logged out
+
+Re-issue the `codeman_session` cookie on every authenticated request so the
+browser cookie lifetime tracks the server-side sliding TTL (the session store
+already uses `refreshOnGet`). Previously the cookie was only set on the Basic
+Auth path with a fixed 24h lifetime from login, so the browser dropped it
+mid-use; the next request arrived cookie-less, fell through to Basic Auth and
+popped the native username/password dialog — perceived as a random logout while
+actively working.

--- a/src/web/middleware/auth.ts
+++ b/src/web/middleware/auth.ts
@@ -151,6 +151,19 @@ export function registerAuthMiddleware(app: FastifyInstance, https: boolean): Au
     // Use get() instead of has() so refreshOnGet extends the TTL on active sessions
     const sessionToken = req.cookies[AUTH_COOKIE_NAME];
     if (sessionToken && authSessions.get(sessionToken) !== undefined) {
+      // Sliding cookie: re-issue on every authenticated request so the browser
+      // cookie lifetime tracks the server-side sliding TTL (refreshOnGet above).
+      // Without this the cookie has a fixed lifetime from login; the browser
+      // drops it mid-use, the next request arrives cookie-less and falls through
+      // to Basic Auth — popping the native username/password dialog, which reads
+      // as a random logout while actively working.
+      reply.setCookie(AUTH_COOKIE_NAME, sessionToken, {
+        httpOnly: true,
+        secure: https,
+        sameSite: 'lax',
+        maxAge: AUTH_SESSION_TTL_MS / 1000, // seconds
+        path: '/',
+      });
       done();
       return;
     }


### PR DESCRIPTION
## Problem

While actively using Codeman, the browser periodically pops the native Basic Auth username/password dialog — perceived as a random logout mid-work.

## Cause

The server-side session store already slides its TTL on access (`StaleExpirationMap({ refreshOnGet: true })`), but the `codeman_session` **cookie** is only ever set on the Basic Auth path, with a fixed `maxAge` from login. On subsequent requests the valid-cookie branch just calls `done()` and never re-issues the cookie. So the browser cookie reaches its fixed expiry mid-session, the next request arrives cookie-less, falls through to Basic Auth, and triggers the `WWW-Authenticate` dialog — even though the server-side session is still alive.

## Fix

Re-issue the cookie on every authenticated (valid-cookie) request so the browser cookie lifetime tracks the server-side sliding TTL. Same cookie attributes as the existing Basic Auth path (`httpOnly`, `secure`, `sameSite: 'lax'`, `path: '/'`, `maxAge = AUTH_SESSION_TTL_MS / 1000`).

## Notes

- No change to session lifetime semantics or the Basic Auth path — only the cookie now slides in lockstep with the store that was already sliding.
- Verified in a live deployment: the recurring Basic Auth prompt no longer appears during active use.
- `tsc --noEmit`, `npm run lint`, and `format:check` pass; changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)