### PR TITLE
feat(cases): add inline edit and delete actions

### DIFF
--- a/src/web/public/session-ui.js
+++ b/src/web/public/session-ui.js
@@ -161,17 +161,37 @@ Object.assign(CodemanApp.prototype, {
         const selected = option.name === selectedName;
         const id = `quickStartCaseOption-${index}`;
         return `
-          <button
-            type="button"
-            id="${id}"
-            class="case-combobox-option ${active ? 'active' : ''} ${selected ? 'selected' : ''}"
-            role="option"
-            aria-selected="${selected ? 'true' : 'false'}"
-            data-case="${escapeHtml(option.name)}"
-            title="${escapeHtml(option.label)}">
-            <span class="case-combobox-check">${selected ? '✓' : ''}</span>
-            <span class="case-combobox-option-label">${escapeHtml(option.label)}</span>
-          </button>
+          <div class="case-combobox-row" data-case="${escapeHtml(option.name)}">
+            <button
+              type="button"
+              id="${id}"
+              class="case-combobox-option ${active ? 'active' : ''} ${selected ? 'selected' : ''}"
+              role="option"
+              aria-selected="${selected ? 'true' : 'false'}"
+              data-case="${escapeHtml(option.name)}"
+              title="${escapeHtml(option.label)}">
+              <span class="case-combobox-check">${selected ? '✓' : ''}</span>
+              <span class="case-combobox-option-label">${escapeHtml(option.label)}</span>
+            </button>
+            <span class="case-combobox-actions">
+              <button type="button" class="case-combobox-action" data-case-action="edit"
+                      title="Edit case settings" aria-label="Edit ${escapeHtml(option.label)} settings">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 20h9"/>
+                  <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L8 18l-4 1 1-4Z"/>
+                </svg>
+              </button>
+              <button type="button" class="case-combobox-action case-combobox-action-delete"
+                      data-case-action="delete" title="Delete case"
+                      aria-label="Delete ${escapeHtml(option.label)}">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M3 6h18"/>
+                  <path d="M8 6V4h8v2"/>
+                  <path d="M19 6l-1 14H6L5 6"/>
+                </svg>
+              </button>
+            </span>
+          </div>
         `;
       })
       .join('');
@@ -238,6 +258,20 @@ Object.assign(CodemanApp.prototype, {
     });
     list.addEventListener('mousedown', event => event.preventDefault());
     list.addEventListener('click', event => {
+      const action = event.target.closest?.('[data-case-action]');
+      if (action) {
+        event.preventDefault();
+        event.stopPropagation();
+        const caseName = action.closest('.case-combobox-row')?.dataset?.case;
+        if (!caseName) return;
+        if (action.dataset.caseAction === 'edit') {
+          this.editCaseFromPicker(caseName);
+        } else if (action.dataset.caseAction === 'delete') {
+          this.closeCasePicker();
+          this.deleteCase(caseName);
+        }
+        return;
+      }
       const option = event.target.closest?.('.case-combobox-option');
       if (option?.dataset?.case) {
         this.selectQuickStartCase(option.dataset.case);
@@ -1637,6 +1671,23 @@ Object.assign(CodemanApp.prototype, {
     if (desktopOpusCheckbox) desktopOpusCheckbox.checked = settings.opusContext1m;
   },
 
+  editCaseFromPicker(caseName, mobile = false) {
+    this.selectQuickStartCase(caseName);
+    if (mobile) this.closeMobileCasePicker();
+
+    const popover = document.getElementById(
+      mobile ? 'caseSettingsPopoverMobile' : 'caseSettingsPopover'
+    );
+    // Force the existing toggle onto its open path even if another case's
+    // settings popover was already visible.
+    popover?.classList.add('hidden');
+    if (mobile) {
+      this.toggleCaseSettingsMobile();
+    } else {
+      this.toggleCaseSettings();
+    }
+  },
+
   // ═══════════════════════════════════════════════════════════════
   // Create Case Modal
   // ═══════════════════════════════════════════════════════════════
@@ -2441,25 +2492,41 @@ Object.assign(CodemanApp.prototype, {
     for (const c of allCases) {
       const isSelected = c.name === currentCase;
       html += `
-        <button class="mobile-case-item ${isSelected ? 'selected' : ''}"
-                onclick="app.selectMobileCase(${escapeHtml(JSON.stringify(c.name))})">
-          <span class="mobile-case-item-icon">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
-            </svg>
+        <div class="mobile-case-item ${isSelected ? 'selected' : ''}">
+          <button type="button" class="mobile-case-item-select"
+                  onclick="app.selectMobileCase(${escapeHtml(JSON.stringify(c.name))})">
+            <span class="mobile-case-item-icon">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+              </svg>
+            </span>
+            <span class="mobile-case-item-name">${escapeHtml(c.label)}</span>
+            <span class="mobile-case-item-check">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+            </span>
+          </button>
+          <span class="mobile-case-item-actions">
+            <button type="button" class="mobile-case-item-action mobile-case-item-edit"
+                    onclick="app.editCaseFromPicker(${escapeHtml(JSON.stringify(c.name))}, true)"
+                    title="Edit case settings" aria-label="Edit ${escapeHtml(c.label)} settings">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 20h9"/>
+                <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L8 18l-4 1 1-4Z"/>
+              </svg>
+            </button>
+            <button type="button" class="mobile-case-item-action mobile-case-item-delete"
+                    onclick="app.deleteCaseMobile(${escapeHtml(JSON.stringify(c.name))})"
+                    title="Delete case" aria-label="Delete ${escapeHtml(c.label)}">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M3 6h18"/>
+                <path d="M8 6V4h8v2"/>
+                <path d="M19 6l-1 14H6L5 6"/>
+              </svg>
+            </button>
           </span>
-          <span class="mobile-case-item-name">${escapeHtml(c.label)}</span>
-          <span class="mobile-case-item-delete" onclick="event.stopPropagation(); app.deleteCaseMobile(${escapeHtml(JSON.stringify(c.name))})" title="Delete">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
-            </svg>
-          </span>
-          <span class="mobile-case-item-check">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-              <polyline points="20 6 9 17 4 12"/>
-            </svg>
-          </span>
-        </button>
+        </div>
       `;
     }
 

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -4053,13 +4053,21 @@ body.touch-device .terminal-container .xterm .xterm-helper-textarea {
   display: none;
 }
 
+.case-combobox-row {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
 .case-combobox-option {
   display: grid;
   grid-template-columns: 18px minmax(0, 1fr);
   align-items: center;
+  flex: 1;
+  min-width: 0;
   width: 100%;
   min-height: 34px;
-  padding: 0.35rem 0.45rem;
+  padding: 0.35rem 4.2rem 0.35rem 0.45rem;
   background: transparent;
   border: 1px solid transparent;
   border-radius: 6px;
@@ -4091,6 +4099,58 @@ body.touch-device .terminal-container .xterm .xterm-helper-textarea {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.case-combobox-actions {
+  position: absolute;
+  right: 0.3rem;
+  display: flex;
+  gap: 0.15rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-smooth);
+}
+
+.case-combobox-row:hover .case-combobox-actions,
+.case-combobox-row:focus-within .case-combobox-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.case-combobox-action {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-dim);
+  background: #242a34;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.case-combobox-action:hover,
+.case-combobox-action:focus-visible {
+  color: var(--text);
+  background: #303846;
+}
+
+.case-combobox-action-delete:hover,
+.case-combobox-action-delete:focus-visible {
+  color: #f87171;
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+.case-combobox-action svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .case-combobox-empty {
@@ -5059,29 +5119,43 @@ body.touch-device .terminal-container .xterm .xterm-helper-textarea {
 .mobile-case-item {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 14px 20px;
+  padding: 4px 8px;
   background: transparent;
   border: none;
   color: #e5e5e5;
-  font-size: 0.95rem;
-  text-align: left;
-  cursor: pointer;
   transition: background 0.1s;
   width: 100%;
 }
 
-.mobile-case-item:hover {
+.mobile-case-item:hover,
+.mobile-case-item:focus-within {
   background: rgba(255, 255, 255, 0.05);
 }
 
-.mobile-case-item:active {
+.mobile-case-item:has(.mobile-case-item-select:active) {
   background: rgba(255, 255, 255, 0.1);
 }
 
 .mobile-case-item.selected {
   background: rgba(34, 197, 94, 0.15);
   color: #22c55e;
+}
+
+.mobile-case-item-select {
+  display: flex;
+  min-width: 0;
+  min-height: 44px;
+  padding: 8px 4px 8px 12px;
+  align-items: center;
+  flex: 1;
+  gap: 12px;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  font: inherit;
+  font-size: 0.95rem;
+  text-align: left;
+  cursor: pointer;
 }
 
 .mobile-case-item-icon {
@@ -5120,21 +5194,43 @@ body.touch-device .terminal-container .xterm .xterm-helper-textarea {
   opacity: 1;
 }
 
-.mobile-case-item-delete {
-  width: 28px;
-  height: 28px;
+.mobile-case-item-actions {
+  display: flex;
+  flex-shrink: 0;
+  gap: 4px;
+}
+
+.mobile-case-item-action {
+  width: 36px;
+  height: 36px;
+  padding: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   color: var(--text-dim);
-  opacity: 0.4;
   flex-shrink: 0;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 4px;
   transition: all var(--transition-smooth);
 }
 
+.mobile-case-item-action svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.mobile-case-item-edit:active {
+  color: #93c5fd;
+  background: rgba(59, 130, 246, 0.15);
+}
+
 .mobile-case-item-delete:active {
-  opacity: 1;
   color: #ef4444;
   background: rgba(239, 68, 68, 0.15);
 }

--- a/test/run-mode-ui.test.ts
+++ b/test/run-mode-ui.test.ts
@@ -6,7 +6,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import vm from 'node:vm';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 function loadRunModeHarness() {
   const elements: Record<string, any> = {};
@@ -363,6 +363,69 @@ describe('case selector refresh', () => {
 
     expect(elements.quickStartCase.value).toBe('moneytrove');
     expect(app.run).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders distinct edit and delete actions beside every case option', () => {
+    const elements: Record<string, any> = {
+      quickStartCaseSearch: {
+        setAttribute: vi.fn(),
+        removeAttribute: vi.fn(),
+      },
+      quickStartCaseList: {
+        innerHTML: '',
+        classList: { remove: vi.fn() },
+      },
+      quickStartCase: { value: 'Alpha' },
+    };
+    const CodemanApp = function CodemanApp(this: any) {};
+    const context = vm.createContext({
+      CodemanApp,
+      localStorage: { getItem: () => null, setItem: () => {} },
+      document: { getElementById: (id: string) => elements[id] ?? null },
+      console,
+      escapeHtml: (value: string) => value,
+    });
+    const sessionUi = readFileSync(resolve(import.meta.dirname, '../src/web/public/session-ui.js'), 'utf8');
+    vm.runInContext(sessionUi, context, { filename: 'session-ui.js' });
+
+    const app = new (CodemanApp as any)();
+    app.cases = [{ name: 'Alpha' }, { name: 'Beta' }];
+    app.renderCasePickerList();
+
+    expect(elements.quickStartCaseList.innerHTML.match(/data-case-action="edit"/g)).toHaveLength(3);
+    expect(elements.quickStartCaseList.innerHTML.match(/data-case-action="delete"/g)).toHaveLength(3);
+  });
+
+  it('opens the selected case settings directly from an inline edit action', () => {
+    const elements: Record<string, any> = {
+      quickStartCase: { value: 'Alpha' },
+      caseSettingsPopover: {
+        classList: {
+          add: vi.fn(),
+          contains: vi.fn(() => true),
+          remove: vi.fn(),
+        },
+      },
+    };
+    const CodemanApp = function CodemanApp(this: any) {};
+    const context = vm.createContext({
+      CodemanApp,
+      localStorage: { getItem: () => null, setItem: () => {} },
+      document: { getElementById: (id: string) => elements[id] ?? null },
+      console,
+    });
+    const sessionUi = readFileSync(resolve(import.meta.dirname, '../src/web/public/session-ui.js'), 'utf8');
+    vm.runInContext(sessionUi, context, { filename: 'session-ui.js' });
+
+    const app = new (CodemanApp as any)();
+    app.selectQuickStartCase = vi.fn();
+    app.toggleCaseSettings = vi.fn();
+
+    app.editCaseFromPicker('Beta');
+
+    expect(app.selectQuickStartCase).toHaveBeenCalledWith('Beta');
+    expect(elements.caseSettingsPopover.classList.add).toHaveBeenCalledWith('hidden');
+    expect(app.toggleCaseSettings).toHaveBeenCalledOnce();
   });
 
   it('creates remote shell sessions by caseName instead of remote display path', async () => {


### PR DESCRIPTION
## Summary

- Add distinct edit and delete icon actions beside each desktop case-picker option.
- Add separate, touch-sized edit and delete actions to the mobile case picker.
- Reuse the existing case-settings popover and delete-confirmation flow.
- Preserve row selection as a separate action so editing or deleting cannot accidentally launch a case.

## Motivation

Case maintenance was available only through the settings window even though users select cases from the quick-start picker throughout normal work. The extra navigation is especially costly on mobile.

## Scope

This is the inline case-management slice extracted from #173. It includes the picker behavior, the exact desktop/mobile styles required by the new controls, and focused tests. It does not change case APIs or deletion semantics.

## Interaction details

- Desktop actions appear when a row is hovered or contains keyboard focus.
- Mobile keeps the case-selection target at least 44px high and places the two actions at the row edge.
- Delete continues to require the existing user confirmation.

## Validation

- `npx vitest run --config config/vitest.config.ts test/run-mode-ui.test.ts`: 15 passed
- Temporary Playwright probe: 6 mobile action buttons and 2 desktop action buttons visible; all mobile controls remained inside a 390px viewport
- `npm run check:frontend-syntax`: 26 files passed
- `npm run build`: passed
- Commit formatting hook: passed
- `git diff --check`: passed
