### PR TITLE
fix: preserve active terminal across reconnects

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -494,6 +494,9 @@ class CodemanApp {
 
     this._initGeneration = 0;     // dedup concurrent handleInit calls
     this._initFallbackTimer = null; // fallback timer if SSE init doesn't arrive
+    this._serverStartedAt = null; // process epoch from init/status snapshots
+    this._lastInitSnapshotTimestamp = null;
+    this._serverReloadRequested = false;
     this._selectGeneration = 0;   // cancel stale selectSession loads
     this._initialFullBufferLoad = true; // first buffer load after a page load fetches full tmux scrollback (COD-47)
     this.terminalLoadStates = new Map(); // Map<sessionId, { generation, phase }>
@@ -1632,6 +1635,8 @@ class CodemanApp {
   }
 
   _onSessionTerminal(data) {
+    if (this._serverReloadRequested) return;
+
     if (data.id === this.activeSessionId) {
       if (data.data.length > 32768) _crashDiag.log(`TERMINAL: ${(data.data.length/1024).toFixed(0)}KB`);
 
@@ -3020,9 +3025,173 @@ class CodemanApp {
     }
   }
 
+  /**
+   * Distinguish a duplicate snapshot from a new server process. A changed
+   * process can serve different frontend assets, so persist input and replace
+   * the stale page once; a transport reconnect stays on the current page.
+   */
+  _handleServerInitEpoch(serverStartedAt) {
+    if (!Number.isSafeInteger(serverStartedAt) || serverStartedAt <= 0) return 'legacy';
+    if (this._serverReloadRequested) return 'reload';
+
+    const previous = this._serverStartedAt;
+    this._serverStartedAt = serverStartedAt;
+    if (!Number.isSafeInteger(previous) || previous <= 0) return 'initial';
+    if (previous === serverStartedAt) return 'reconnect';
+
+    this._serverReloadRequested = true;
+    this._captureActiveSessionDraft?.();
+    this._inputState?.persistNow?.();
+    this._persistReliableNow?.();
+    window.location.reload();
+    return 'reload';
+  }
+
+  _acceptServerInitSnapshot(timestamp) {
+    if (!Number.isSafeInteger(timestamp) || timestamp <= 0) return true;
+    const previous = this._lastInitSnapshotTimestamp;
+    if (Number.isSafeInteger(previous) && timestamp <= previous) return false;
+    this._lastInitSnapshotTimestamp = timestamp;
+    return true;
+  }
+
+  /**
+   * Apply an authoritative same-process snapshot without clearing or replaying
+   * the active terminal. This catches events missed during an SSE outage while
+   * keeping the current frame, scroll position, and input intact.
+   */
+  _reconcileSameServerInit(data) {
+    const incomingSessions = Array.isArray(data.sessions) ? data.sessions : [];
+    const incomingIds = new Set(incomingSessions.map((session) => session.id));
+
+    for (const sessionId of Array.from(this.sessions.keys())) {
+      if (!incomingIds.has(sessionId)) this._onSessionDeleted({ id: sessionId });
+    }
+
+    let shouldRecheckSubagentParents = false;
+    for (const session of incomingSessions) {
+      const previous = this.sessions.get(session.id);
+      const workingDirectoryChanged = Boolean(
+        previous && session.workingDir && previous.workingDir !== session.workingDir
+      );
+      if (session.claudeSessionId && !previous?.claudeSessionId) {
+        shouldRecheckSubagentParents = true;
+      }
+      this.sessions.set(session.id, session);
+      this.updateSubagentParentNames(session.id);
+
+      if ((session.ralphLoop || session.ralphTodos) && !this.ralphClosedSessions.has(session.id)) {
+        this.ralphStates.set(session.id, {
+          loop: session.ralphLoop || null,
+          todos: session.ralphTodos || [],
+        });
+      } else {
+        this.ralphStates.delete(session.id);
+      }
+
+      if (session.id === this.activeSessionId && session.tokens) {
+        this.updateRespawnTokens(session.tokens);
+      }
+      const locallySavingWorkingDirectory =
+        this._pendingWorkingDirectoryChange?.sessionId === session.id;
+      if (workingDirectoryChanged && session.id === this.activeSessionId && !locallySavingWorkingDirectory) {
+        void this.syncFileBrowserSession?.(session.id, { force: true });
+      }
+    }
+
+    if (shouldRecheckSubagentParents) {
+      this.recheckOrphanSubagents();
+      requestAnimationFrame(() => this.updateConnectionLines());
+    }
+
+    if (Array.isArray(data.sessionOrder) && data.sessionOrder.length) {
+      try { localStorage.setItem('codeman-session-order', JSON.stringify(data.sessionOrder)); } catch {}
+    }
+    this.syncSessionOrder();
+
+    if (!this.activeSessionId && !this.isSoloWindow && this.sessionOrder.length > 0) {
+      this.selectSession(this.sessionOrder[0]);
+    }
+
+    this.respawnStatus = data.respawnStatus || {};
+    this.globalStats = data.globalStats || null;
+
+    const scheduledRuns = Array.isArray(data.scheduledRuns) ? data.scheduledRuns : [];
+    this.totalCost = incomingSessions.reduce((sum, session) => sum + (session.totalCost || 0), 0);
+    this.totalCost += scheduledRuns.reduce((sum, run) => sum + (run.totalCost || 0), 0);
+
+    const activeRun = scheduledRuns.find((run) => run.status === 'running') || null;
+    this.currentRun = activeRun;
+    if (activeRun) {
+      if (this.timerInterval) this.updateTimer();
+      else this.showTimer();
+    } else {
+      this.hideTimer();
+    }
+
+    if (data.planUsage) this.updatePlanUsageChip(data.planUsage);
+
+    if (Array.isArray(data.subagents)) {
+      const incomingAgentIds = new Set(data.subagents.map((agent) => agent.agentId));
+      for (const agentId of Array.from(this.subagents.keys())) {
+        if (incomingAgentIds.has(agentId)) continue;
+        this.forceCloseSubagentWindow(agentId);
+        this.subagents.delete(agentId);
+        this.subagentActivity.delete(agentId);
+        this.subagentToolResults.delete(agentId);
+        for (const [sessionId, minimizedAgentIds] of this.minimizedSubagents) {
+          minimizedAgentIds.delete(agentId);
+          if (minimizedAgentIds.size === 0) this.minimizedSubagents.delete(sessionId);
+        }
+        if (this.activeSubagentId === agentId) this.activeSubagentId = null;
+      }
+
+      for (const agent of data.subagents) {
+        const previous = this.subagents.get(agent.agentId);
+        this.subagents.set(agent.agentId, previous ? { ...previous, ...agent } : agent);
+        if (!previous) {
+          this.subagentActivity.set(agent.agentId, []);
+          this.findParentSessionForSubagent(agent.agentId);
+        }
+      }
+      this.renderSubagentPanel();
+      this.updateSubagentWindows();
+    }
+
+    if (Array.isArray(data.workflowRuns)) {
+      const incomingRunIds = new Set(data.workflowRuns.map((run) => run.runId));
+      for (const runId of Array.from(this.workflowRuns.keys())) {
+        if (incomingRunIds.has(runId)) continue;
+        this.workflowRunDetails.delete(runId);
+        if (this.activeWorkflowRunId === runId) this.activeWorkflowRunId = null;
+        this.closeUltracodeWindow?.(runId, false);
+      }
+      this.seedWorkflowRuns(data.workflowRuns);
+    }
+
+    this.updateCost();
+    this.renderSessionTabs();
+    this.renderRalphStatePanel();
+    if (this.sessions.size > 0) {
+      if (!this.systemStatsInterval) this.startSystemStatsPolling();
+    } else {
+      this.stopSystemStatsPolling();
+    }
+  }
+
   handleInit(data) {
     // Clear the init fallback timer since we got data
     this._clearTimer('_initFallbackTimer');
+
+    const initAction = this._handleServerInitEpoch(data.serverStartedAt);
+    if (initAction === 'reload') return;
+    if (initAction === 'reconnect') {
+      if (!this._acceptServerInitSnapshot(data.timestamp)) return;
+      this._reconcileSameServerInit(data);
+      return;
+    }
+    if (initAction === 'initial') this._acceptServerInitSnapshot(data.timestamp);
+
     const gen = ++this._initGeneration;
 
     // CJK input form: controlled by user setting (with server env as override)
@@ -3192,11 +3361,14 @@ class CodemanApp {
   }
 
   async loadState() {
+    const initGenerationAtRequest = this._initGeneration;
     try {
       const res = await fetch('/api/status');
       const data = await res.json();
+      if (this._initGeneration !== initGenerationAtRequest) return;
       this.handleInit(data?.data ?? {});
     } catch (err) {
+      if (this._initGeneration !== initGenerationAtRequest) return;
       console.error('Failed to load state:', err);
     }
   }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1880,6 +1880,7 @@ export class WebServer extends EventEmitter {
 
     const result = {
       version: APP_VERSION,
+      serverStartedAt: this.serverStartTime,
       sessions: this.getLightSessionsState(),
       scheduledRuns: Array.from(this.scheduledRuns.values()),
       respawnStatus,

--- a/test/server-init-lifecycle.test.ts
+++ b/test/server-init-lifecycle.test.ts
@@ -1,0 +1,265 @@
+/**
+ * @fileoverview Client init lifecycle regression tests.
+ *
+ * A same-process SSE reconnect must reconcile metadata without destroying and
+ * replaying the active terminal. A changed process epoch must persist input and
+ * reload once so an already-open browser does not keep running stale assets.
+ */
+import { readFileSync } from 'node:fs';
+import { performance } from 'node:perf_hooks';
+import { resolve } from 'node:path';
+import vm from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+
+type InitAction = 'legacy' | 'initial' | 'reconnect' | 'reload';
+
+type InitApp = {
+  _serverStartedAt: number | null;
+  _lastInitSnapshotTimestamp: number | null;
+  _serverReloadRequested: boolean;
+  _initGeneration: number;
+  _handleServerInitEpoch: (serverStartedAt: unknown) => InitAction;
+  _acceptServerInitSnapshot: (timestamp: unknown) => boolean;
+  _reconcileSameServerInit: (data: unknown) => void;
+  handleInit: (data: Record<string, unknown>) => void;
+  loadState: () => Promise<void>;
+  _onSessionTerminal: (data: { id: string; data: string }) => void;
+  _clearTimer: ReturnType<typeof vi.fn>;
+  _captureActiveSessionDraft: ReturnType<typeof vi.fn>;
+  _persistReliableNow: ReturnType<typeof vi.fn>;
+  batchTerminalWrite: ReturnType<typeof vi.fn>;
+  activeSessionId: string | null;
+  _inputState: { persistNow: ReturnType<typeof vi.fn> };
+  _resetAllAppState: ReturnType<typeof vi.fn>;
+};
+
+function loadHarness() {
+  const reload = vi.fn();
+  const fetchMock = vi.fn();
+  const constants = readFileSync(resolve(import.meta.dirname, '../src/web/public/constants.js'), 'utf8');
+  const source = readFileSync(resolve(import.meta.dirname, '../src/web/public/app.js'), 'utf8');
+  const context = vm.createContext({
+    console,
+    performance,
+    setInterval: vi.fn(),
+    clearInterval: vi.fn(),
+    setTimeout: vi.fn(),
+    clearTimeout: vi.fn(),
+    requestAnimationFrame: vi.fn(),
+    HTMLCanvasElement: class HTMLCanvasElement {},
+    location: { protocol: 'https:', host: 'test.local' },
+    fetch: fetchMock,
+    document: { addEventListener: vi.fn() },
+    localStorage: {
+      length: 0,
+      key: vi.fn(),
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    },
+    window: {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      location: { reload },
+    },
+    MobileDetection: {},
+  });
+  vm.runInContext(`${constants}\n${source}\nglobalThis.__CodemanApp = CodemanApp;`, context);
+  const CodemanApp = (context as { __CodemanApp: new () => unknown }).__CodemanApp;
+  return { CodemanApp, fetchMock, reload };
+}
+
+function makeApp(CodemanApp: new () => unknown): InitApp {
+  const app = Object.create((CodemanApp as { prototype: object }).prototype) as InitApp;
+  app._serverStartedAt = null;
+  app._lastInitSnapshotTimestamp = null;
+  app._serverReloadRequested = false;
+  app._initGeneration = 1;
+  app._clearTimer = vi.fn();
+  app._captureActiveSessionDraft = vi.fn();
+  app._persistReliableNow = vi.fn();
+  app.batchTerminalWrite = vi.fn();
+  app.activeSessionId = 'session-1';
+  app._inputState = { persistNow: vi.fn() };
+  app._resetAllAppState = vi.fn();
+  return app;
+}
+
+describe('client server-init lifecycle', () => {
+  it('distinguishes initial load and same-process reconnect by server epoch', () => {
+    const { CodemanApp } = loadHarness();
+    const app = makeApp(CodemanApp);
+
+    expect(app._handleServerInitEpoch(undefined)).toBe('legacy');
+    expect(app._handleServerInitEpoch(100)).toBe('initial');
+    expect(app._handleServerInitEpoch(100)).toBe('reconnect');
+  });
+
+  it('persists editable and queued input before reloading stale assets once', () => {
+    const { CodemanApp, reload } = loadHarness();
+    const app = makeApp(CodemanApp);
+    app._serverStartedAt = 100;
+
+    expect(app._handleServerInitEpoch(200)).toBe('reload');
+    expect(app._captureActiveSessionDraft).toHaveBeenCalledOnce();
+    expect(app._inputState.persistNow).toHaveBeenCalledOnce();
+    expect(app._persistReliableNow).toHaveBeenCalledOnce();
+    expect(reload).toHaveBeenCalledOnce();
+
+    expect(app._handleServerInitEpoch(300)).toBe('reload');
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('routes a same-process init through reconciliation without terminal reset', () => {
+    const { CodemanApp } = loadHarness();
+    const app = makeApp(CodemanApp);
+    const reconcile = vi.fn();
+    app._serverStartedAt = 100;
+    app._reconcileSameServerInit = reconcile;
+
+    const snapshot = { serverStartedAt: 100, timestamp: 200, sessions: [] };
+    app.handleInit(snapshot);
+
+    expect(reconcile).toHaveBeenCalledWith(snapshot);
+    expect(app._resetAllAppState).not.toHaveBeenCalled();
+    expect(app._initGeneration).toBe(1);
+  });
+
+  it('ignores an older same-process snapshot that arrives out of order', () => {
+    const { CodemanApp } = loadHarness();
+    const app = makeApp(CodemanApp);
+    const reconcile = vi.fn();
+    app._serverStartedAt = 100;
+    app._lastInitSnapshotTimestamp = 200;
+    app._reconcileSameServerInit = reconcile;
+
+    app.handleInit({ serverStartedAt: 100, timestamp: 150, sessions: [] });
+
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(app._resetAllAppState).not.toHaveBeenCalled();
+    expect(app._lastInitSnapshotTimestamp).toBe(200);
+  });
+
+  it('discards a late HTTP fallback after SSE initialization wins the race', async () => {
+    const { CodemanApp, fetchMock } = loadHarness();
+    const app = makeApp(CodemanApp);
+    const handleInit = vi.fn();
+    app.handleInit = handleInit;
+    let resolveFetch: (response: { json: () => Promise<unknown> }) => void = () => {};
+    fetchMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+
+    const fallback = app.loadState();
+    app._initGeneration += 1;
+    resolveFetch({ json: async () => ({ data: { serverStartedAt: 100 } }) });
+    await fallback;
+
+    expect(handleInit).not.toHaveBeenCalled();
+  });
+
+  it('reconciles missed metadata while retaining the active session', () => {
+    const { CodemanApp } = loadHarness();
+    const app = makeApp(CodemanApp) as InitApp & Record<string, any>;
+    app.sessions = new Map([
+      ['session-1', { id: 'session-1', name: 'before', totalCost: 1, workingDir: '/before' }],
+      ['stale-session', { id: 'stale-session' }],
+    ]);
+    app.ralphStates = new Map([['session-1', { loop: {}, todos: [] }]]);
+    app.ralphClosedSessions = new Set();
+    app.sessionOrder = ['session-1', 'stale-session'];
+    app.isSoloWindow = false;
+    app.subagents = new Map([
+      ['agent-1', { agentId: 'agent-1', status: 'running' }],
+      ['stale-agent', { agentId: 'stale-agent', status: 'completed' }],
+    ]);
+    app.subagentActivity = new Map([['stale-agent', []]]);
+    app.subagentToolResults = new Map([['stale-agent', new Map()]]);
+    app.minimizedSubagents = new Map([['session-1', new Set(['stale-agent'])]]);
+    app.activeSubagentId = 'stale-agent';
+    app.workflowRuns = new Map([
+      ['run-1', { runId: 'run-1' }],
+      ['stale-run', { runId: 'stale-run' }],
+    ]);
+    app.workflowRunDetails = new Map([['stale-run', {}]]);
+    app.activeWorkflowRunId = 'stale-run';
+    app.systemStatsInterval = {};
+    app.timerInterval = {};
+
+    app._onSessionDeleted = vi.fn(({ id }) => app.sessions.delete(id));
+    app.updateSubagentParentNames = vi.fn();
+    app.updateRespawnTokens = vi.fn();
+    app.syncFileBrowserSession = vi.fn();
+    app.recheckOrphanSubagents = vi.fn();
+    app.updateConnectionLines = vi.fn();
+    app.syncSessionOrder = vi.fn(() => {
+      app.sessionOrder = ['session-1'];
+    });
+    app.selectSession = vi.fn();
+    app.updateTimer = vi.fn();
+    app.showTimer = vi.fn();
+    app.hideTimer = vi.fn();
+    app.updatePlanUsageChip = vi.fn();
+    app.forceCloseSubagentWindow = vi.fn();
+    app.findParentSessionForSubagent = vi.fn();
+    app.renderSubagentPanel = vi.fn();
+    app.updateSubagentWindows = vi.fn();
+    app.closeUltracodeWindow = vi.fn();
+    app.seedWorkflowRuns = vi.fn((runs) => {
+      app.workflowRuns = new Map(runs.map((run: { runId: string }) => [run.runId, run]));
+    });
+    app.updateCost = vi.fn();
+    app.renderSessionTabs = vi.fn();
+    app.renderRalphStatePanel = vi.fn();
+    app.startSystemStatsPolling = vi.fn();
+    app.stopSystemStatsPolling = vi.fn();
+
+    app._reconcileSameServerInit({
+      sessions: [
+        {
+          id: 'session-1',
+          name: 'after',
+          totalCost: 3,
+          tokens: { input: 10 },
+          workingDir: '/after',
+        },
+      ],
+      sessionOrder: ['session-1'],
+      scheduledRuns: [],
+      respawnStatus: { 'session-1': { enabled: true } },
+      subagents: [
+        { agentId: 'agent-1', status: 'completed' },
+        { agentId: 'agent-2', status: 'running' },
+      ],
+      workflowRuns: [{ runId: 'run-1', status: 'running' }],
+    });
+
+    expect(app.activeSessionId).toBe('session-1');
+    expect(app.selectSession).not.toHaveBeenCalled();
+    expect(app.sessions.get('session-1')?.name).toBe('after');
+    expect(app.sessions.has('stale-session')).toBe(false);
+    expect(app.ralphStates.has('session-1')).toBe(false);
+    expect(app.syncFileBrowserSession).toHaveBeenCalledWith('session-1', { force: true });
+    expect(app.totalCost).toBe(3);
+    expect(app.currentRun).toBeNull();
+    expect(app.hideTimer).toHaveBeenCalledOnce();
+    expect(app.forceCloseSubagentWindow).toHaveBeenCalledWith('stale-agent');
+    expect(app.minimizedSubagents.size).toBe(0);
+    expect(app.subagents.get('agent-1')?.status).toBe('completed');
+    expect(app.findParentSessionForSubagent).toHaveBeenCalledWith('agent-2');
+    expect(app.workflowRunDetails.has('stale-run')).toBe(false);
+    expect(app.closeUltracodeWindow).toHaveBeenCalledWith('stale-run', false);
+  });
+
+  it('drops terminal output after a replacement page has been requested', () => {
+    const { CodemanApp } = loadHarness();
+    const app = makeApp(CodemanApp);
+    app._serverReloadRequested = true;
+
+    app._onSessionTerminal({ id: 'session-1', data: 'stale reconnect redraw' });
+
+    expect(app.batchTerminalWrite).not.toHaveBeenCalled();
+  });
+});

--- a/test/sse-events.test.ts
+++ b/test/sse-events.test.ts
@@ -100,6 +100,11 @@ describe('SSE Events', () => {
       expect((initEvent?.data as any).scheduledRuns).toBeDefined();
       expect((initEvent?.data as any).respawnStatus).toBeDefined();
       expect((initEvent?.data as any).timestamp).toBeDefined();
+      expect(Number.isSafeInteger((initEvent?.data as any).serverStartedAt)).toBe(true);
+
+      const statusResponse = await fetch(`${baseUrl}/api/status`);
+      const statusBody = await statusResponse.json();
+      expect(statusBody.data.serverStartedAt).toBe((initEvent?.data as any).serverStartedAt);
     });
 
     it('should receive session:created event when session is created', async () => {
@@ -160,6 +165,7 @@ describe('SSE Events', () => {
       expect(body.data).toHaveProperty('scheduledRuns');
       expect(body.data).toHaveProperty('respawnStatus');
       expect(body.data).toHaveProperty('timestamp');
+      expect(Number.isSafeInteger(body.data.serverStartedAt)).toBe(true);
     });
 
     it('should include active sessions', async () => {


### PR DESCRIPTION
## Summary

Preserve the active terminal across same-process SSE reconnects instead of clearing state and replaying terminal history.

Extracted from #173 as a focused lifecycle fix.

## Behavior

- Add a stable `serverStartedAt` process epoch to both SSE init and `/api/status`.
- Treat an initial load, same-process reconnect, and changed server process as distinct cases.
- Reconcile authoritative session, cost, timer, subagent, and workflow metadata in place on reconnect.
- Preserve the active xterm instance, buffer, geometry, scroll position, input, and terminal caches.
- Persist available draft/input state and reload once when the server process changes.
- Ignore stale HTTP fallback responses and equal/older init snapshots.
- Drop terminal frames after a replacement page has been requested.
- Keep repository-viewer scope synchronized when a reconnect reveals a changed active working directory.

## Commits

1. `feat(server): identify init snapshots by process`
2. `fix(client): preserve terminal across reconnects`

## Verification

- `npx vitest run test/server-init-lifecycle.test.ts` - 7 tests passed
- `npx vitest run test/sse-events.test.ts` - 7 tests passed
- `npm run check:lockfile`
- `npm run typecheck`
- `npm run lint`
- `npm run check:frontend-syntax`
- `npm run check:public-assets`
- `npm run format:check`
- `npm run build`
- Playwright at a 390x844 touch viewport against the production bundle:
  - one newer snapshot reconciled in place
  - an immediate duplicate snapshot was ignored
  - zero app resets and zero session reselections
  - active session, xterm instance, buffer object, and terminal geometry remained identical

## Scope

No terminal rendering, input parsing, gesture controls, shutdown behavior, or repository-browser implementation is included. Optional draft and repository-viewer hooks compose with their separate PRs without making them dependencies.
